### PR TITLE
Add dynamic page titles based on current view

### DIFF
--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -51,6 +51,7 @@ export {
 } from './useCustomEmojis';
 export { useSearch } from './useSearch';
 export { useIsMobile } from './useIsMobile';
+export { usePageTitle } from './usePageTitle';
 export { useMobileNav } from './useMobileNav';
 export {
   usePinnedMessages,

--- a/apps/web/src/hooks/usePageTitle.ts
+++ b/apps/web/src/hooks/usePageTitle.ts
@@ -1,0 +1,49 @@
+import { useEffect, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from './useAuth';
+import { useChannels } from './useChannels';
+
+const APP_NAME = 'Enzyme';
+
+/**
+ * Sets document.title based on the current page context.
+ *
+ * Reads :workspaceId from the URL automatically via useParams.
+ * Within a workspace route: "(N) Page Title - Workspace Name"
+ *   where N is the total notification_count (mentions + DMs), not total unreads.
+ * Outside a workspace route: "Page Title - Enzyme"
+ * Fallback: "Enzyme"
+ */
+export function usePageTitle(pageTitle?: string) {
+  const { workspaceId } = useParams<{ workspaceId: string }>();
+  const { workspaces } = useAuth();
+  const { data: channelsData } = useChannels(workspaceId);
+
+  const workspaceName = useMemo(
+    () => workspaces?.find((ws) => ws.id === workspaceId)?.name,
+    [workspaces, workspaceId],
+  );
+
+  const totalNotifications = useMemo(
+    () =>
+      workspaceId
+        ? (channelsData?.channels.reduce((sum, c) => sum + c.notification_count, 0) ?? 0)
+        : 0,
+    [workspaceId, channelsData?.channels],
+  );
+
+  useEffect(() => {
+    const parts: string[] = [];
+
+    if (workspaceId) {
+      const notifPrefix = totalNotifications > 0 ? `(${totalNotifications}) ` : '';
+      if (pageTitle) parts.push(pageTitle);
+      if (workspaceName) parts.push(workspaceName);
+      document.title = parts.length > 0 ? notifPrefix + parts.join(' - ') : APP_NAME;
+    } else {
+      if (pageTitle) parts.push(pageTitle);
+      parts.push(APP_NAME);
+      document.title = parts.join(' - ');
+    }
+  }, [pageTitle, workspaceId, workspaceName, totalNotifications]);
+}

--- a/apps/web/src/pages/AcceptInvitePage.tsx
+++ b/apps/web/src/pages/AcceptInvitePage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
-import { useAcceptInvite, useAuth } from '../hooks';
+import { useAcceptInvite, useAuth, usePageTitle } from '../hooks';
 import { Button, Spinner } from '../components/ui';
 
 export function AcceptInvitePage() {
+  usePageTitle('Join Workspace');
   const { code } = useParams<{ code: string }>();
   const navigate = useNavigate();
   const { isAuthenticated, isLoading: authLoading, workspaces } = useAuth();

--- a/apps/web/src/pages/AllUnreadsPage.tsx
+++ b/apps/web/src/pages/AllUnreadsPage.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import { HashtagIcon, LockClosedIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import { useAllUnreads } from '../hooks/useAllUnreads';
+import { usePageTitle } from '../hooks';
 import { Spinner } from '../components/ui';
 import { formatRelativeTime } from '../lib/utils';
 import type { UnreadMessage } from '@enzyme/api-client';
@@ -71,6 +72,7 @@ function UnreadMessageItem({
 
 export function AllUnreadsPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
+  usePageTitle('Unreads');
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useAllUnreads({
     workspaceId: workspaceId || '',
   });

--- a/apps/web/src/pages/ChannelPage.tsx
+++ b/apps/web/src/pages/ChannelPage.tsx
@@ -26,6 +26,7 @@ import {
   useAutoFocusComposer,
   useChannelNotifications,
   useUpdateChannelNotifications,
+  usePageTitle,
 } from '../hooks';
 import { useThreadPanel } from '../hooks/usePanel';
 import { useMarkChannelAsRead, useStarChannel, useUnstarChannel } from '../hooks/useChannels';
@@ -84,6 +85,12 @@ export function ChannelPage() {
   const dmDisplayName = isDM
     ? channel?.dm_participants?.map((p) => p.display_name).join(', ') || channel?.name
     : channel?.name;
+  const pageTitle = channel
+    ? isDM
+      ? `DM with ${dmDisplayName}`
+      : `${getChannelPrefix(channel.type)}${channel.name}`
+    : undefined;
+  usePageTitle(pageTitle);
   const dmPresence = useUserPresence(
     channel?.type === 'dm' && dmParticipant ? dmParticipant.user_id : '',
   );

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import { LoginForm } from '../components/auth';
-import { useAuth, useCreateWorkspace } from '../hooks';
+import { useAuth, useCreateWorkspace, usePageTitle } from '../hooks';
 import { Spinner, Button, Input, toast } from '../components/ui';
 
 export function LoginPage() {
+  usePageTitle('Log in');
   const { isAuthenticated, isLoading, workspaces } = useAuth();
   const [workspaceName, setWorkspaceName] = useState('');
   const createWorkspace = useCreateWorkspace();

--- a/apps/web/src/pages/RegisterPage.tsx
+++ b/apps/web/src/pages/RegisterPage.tsx
@@ -1,8 +1,9 @@
 import { Navigate } from 'react-router-dom';
 import { RegisterForm } from '../components/auth';
-import { useAuth } from '../hooks';
+import { useAuth, usePageTitle } from '../hooks';
 
 export function RegisterPage() {
+  usePageTitle('Register');
   const { isAuthenticated, isLoading, workspaces } = useAuth();
 
   if (isLoading) {

--- a/apps/web/src/pages/ScheduledMessagesPage.tsx
+++ b/apps/web/src/pages/ScheduledMessagesPage.tsx
@@ -12,6 +12,7 @@ import {
   useSendScheduledMessageNow,
   useRetryScheduledMessage,
 } from '../hooks/useScheduledMessages';
+import { usePageTitle } from '../hooks';
 import { EditScheduledMessageModal } from '../components/message/EditScheduledMessageModal';
 import { Spinner, Button } from '../components/ui';
 import type { ScheduledMessage } from '@enzyme/api-client';
@@ -112,6 +113,7 @@ function ScheduledMessageItem({
 
 export function ScheduledMessagesPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
+  usePageTitle('Scheduled');
   const { data, isLoading } = useScheduledMessages(workspaceId || '');
   const deleteMutation = useDeleteScheduledMessage();
   const sendNowMutation = useSendScheduledMessageNow();

--- a/apps/web/src/pages/ThreadsPage.tsx
+++ b/apps/web/src/pages/ThreadsPage.tsx
@@ -7,6 +7,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { useUserThreads } from '../hooks/useThreads';
 import { useThreadPanel } from '../hooks/usePanel';
+import { usePageTitle } from '../hooks';
 import { Spinner, Avatar } from '../components/ui';
 import { cn, formatRelativeTime } from '../lib/utils';
 import type { ThreadMessage } from '@enzyme/api-client';
@@ -99,6 +100,7 @@ function ThreadItem({ thread, onOpen }: { thread: ThreadMessage; onOpen: (id: st
 
 export function ThreadsPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
+  usePageTitle('Threads');
   const { openThread } = useThreadPanel();
   const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } = useUserThreads({
     workspaceId: workspaceId || '',

--- a/apps/web/src/pages/WorkspaceLandingPage.tsx
+++ b/apps/web/src/pages/WorkspaceLandingPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useChannels, useIsMobile } from '../hooks';
+import { useChannels, useIsMobile, usePageTitle } from '../hooks';
 import { Spinner } from '../components/ui';
 
 export function WorkspaceLandingPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
+  usePageTitle();
   const navigate = useNavigate();
   const { data, isLoading } = useChannels(workspaceId);
   const isMobile = useIsMobile();


### PR DESCRIPTION
## Summary
- Add a `usePageTitle` hook that sets `document.title` based on the current route context — channel name, workspace name, and notification badge count
- Each page component calls the hook with its own title string (e.g., `#general - Acme Corp`, `DM with Alice - Acme Corp`, `Threads - Acme Corp`, `Log in - Enzyme`)
- Notification count prefix `(N)` uses `notification_count` (mentions + DMs) to match Slack convention

## Test plan
- Navigate between channels and verify the browser tab updates to `#channel-name - Workspace Name`
- Open a DM and verify the title shows `DM with Display Name - Workspace Name`
- Receive a mention while viewing another channel — verify `(N)` prefix appears in the tab title
- Navigate to Unreads, Threads, and Scheduled pages — verify correct titles
- Switch workspaces and verify the workspace name updates
- Visit login/register pages and verify titles end with `- Enzyme`

Closes #137