### PR TITLE
Fix AvatarStack missing Gravatar in ChannelMembersButton

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'coverage']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/apps/web/src/components/channel/ChannelMembersButton.tsx
+++ b/apps/web/src/components/channel/ChannelMembersButton.tsx
@@ -40,6 +40,7 @@ export function ChannelMembersButton({
     user_id: m.user_id,
     display_name: m.display_name,
     avatar_url: m.avatar_url,
+    gravatar_url: m.gravatar_url,
   }));
 
   return (


### PR DESCRIPTION
## Summary
- ChannelMembersButton was the only AvatarStack call site that omitted `gravatar_url` when mapping channel members, causing avatars to fall back to initials instead of Gravatar images
- Also excludes `coverage/` from eslint config to silence warnings on generated coverage report files

## Test plan
- Open a channel and observe the member avatars in the header — users with Gravatar accounts should now show their Gravatar image instead of initials
- Run `pnpm --filter @enzyme/web test -- --run AvatarStack` — all 10 tests pass
- Run `make lint` — zero warnings

Closes #132