### PR TITLE
Add forgot password UI and wire up reset email

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -173,6 +173,7 @@ func New(cfg *config.Config) (*App, error) {
 		ThreadRepo:          threadRepo,
 		EmojiRepo:           emojiRepo,
 		ScheduledRepo:       scheduledRepo,
+		EmailService:        emailService,
 		NotificationService: notificationService,
 		ModerationRepo:      moderationRepo,
 		Hub:                 hub,

--- a/api/internal/email/service.go
+++ b/api/internal/email/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"log/slog"
+	"net/url"
 
 	"github.com/enzyme/api/internal/config"
 )
@@ -65,19 +66,17 @@ func (s *Service) SendWorkspaceInvite(ctx context.Context, to string, data Invit
 	return s.sender.Send(ctx, to, subject, body, "")
 }
 
-type PasswordResetEmailData struct {
-	ResetURL string
-}
+func (s *Service) SendPasswordReset(ctx context.Context, to string, token string) error {
+	resetURL := s.publicURL + "/reset-password?" + url.Values{"token": {token}}.Encode()
 
-func (s *Service) SendPasswordReset(ctx context.Context, to string, data PasswordResetEmailData) error {
 	if !s.enabled {
-		slog.Debug("would send password reset", "component", "email", "to", to)
+		slog.Debug("would send password reset", "component", "email", "to", to, "url", resetURL)
 		return nil
 	}
 
 	subject := "Reset your Enzyme password"
 	body := "You requested to reset your password.\n\n"
-	body += "Click here to reset: " + data.ResetURL + "\n\n"
+	body += "Click here to reset: " + resetURL + "\n\n"
 	body += "If you didn't request this, you can ignore this email.\n"
 
 	return s.sender.Send(ctx, to, subject, body, "")

--- a/api/internal/handler/auth.go
+++ b/api/internal/handler/auth.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/enzyme/api/internal/auth"
@@ -153,8 +154,21 @@ func (h *Handler) GetMe(ctx context.Context, request openapi.GetMeRequestObject)
 
 // ForgotPassword handles password reset requests
 func (h *Handler) ForgotPassword(ctx context.Context, request openapi.ForgotPasswordRequestObject) (openapi.ForgotPasswordResponseObject, error) {
-	// Always return success to not reveal if email exists
-	_, _ = h.authService.CreatePasswordResetToken(ctx, string(request.Body.Email))
+	token, err := h.authService.CreatePasswordResetToken(ctx, string(request.Body.Email))
+	if err != nil {
+		slog.Error("failed to create password reset token", "error", err)
+	}
+
+	if token != "" {
+		emailAddr := string(request.Body.Email)
+		go func() {
+			sendCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := h.emailService.SendPasswordReset(sendCtx, emailAddr, token); err != nil {
+				slog.Error("failed to send password reset email", "error", err)
+			}
+		}()
+	}
 
 	success := true
 	msg := "If the email exists, a reset link will be sent"

--- a/api/internal/handler/auth_test.go
+++ b/api/internal/handler/auth_test.go
@@ -1,10 +1,14 @@
 package handler
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/enzyme/api/internal/openapi"
+	"github.com/enzyme/api/internal/testutil"
 	"github.com/enzyme/api/internal/user"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 func TestUserToAPI(t *testing.T) {
@@ -63,6 +67,41 @@ func TestUserToAPI_NilOptionalFields(t *testing.T) {
 	}
 	if apiUser.EmailVerifiedAt != nil {
 		t.Error("expected EmailVerifiedAt to be nil")
+	}
+}
+
+func TestForgotPassword(t *testing.T) {
+	h, db := testHandler(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		email string
+	}{
+		{"registered email returns success", "alice@example.com"},
+		{"unknown email returns success", "nobody@example.com"},
+	}
+
+	// Create a test user
+	testutil.CreateTestUser(t, db, "alice@example.com", "Alice")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := openapi.ForgotPasswordJSONRequestBody{
+				Email: openapi_types.Email(tt.email),
+			}
+			resp, err := h.ForgotPassword(ctx, openapi.ForgotPasswordRequestObject{Body: &body})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			okResp, ok := resp.(openapi.ForgotPassword200JSONResponse)
+			if !ok {
+				t.Fatalf("expected 200 response, got %T", resp)
+			}
+			if okResp.Success == nil || !*okResp.Success {
+				t.Error("expected success=true")
+			}
+		})
 	}
 }
 

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/enzyme/api/internal/auth"
 	"github.com/enzyme/api/internal/channel"
+	"github.com/enzyme/api/internal/email"
 	"github.com/enzyme/api/internal/emoji"
 	"github.com/enzyme/api/internal/file"
 	"github.com/enzyme/api/internal/linkpreview"
@@ -38,6 +39,7 @@ type Handler struct {
 	threadRepo          *thread.Repository
 	emojiRepo           *emoji.Repository
 	scheduledRepo       *scheduled.Repository
+	emailService        *email.Service
 	notificationService *notification.Service
 	moderationRepo      *moderation.Repository
 	hub                 *sse.Hub
@@ -61,6 +63,7 @@ type Dependencies struct {
 	ThreadRepo          *thread.Repository
 	EmojiRepo           *emoji.Repository
 	ScheduledRepo       *scheduled.Repository
+	EmailService        *email.Service
 	NotificationService *notification.Service
 	ModerationRepo      *moderation.Repository
 	Hub                 *sse.Hub
@@ -85,6 +88,7 @@ func New(deps Dependencies) *Handler {
 		threadRepo:          deps.ThreadRepo,
 		emojiRepo:           deps.EmojiRepo,
 		scheduledRepo:       deps.ScheduledRepo,
+		emailService:        deps.EmailService,
 		notificationService: deps.NotificationService,
 		moderationRepo:      deps.ModerationRepo,
 		hub:                 deps.Hub,

--- a/api/internal/handler/helpers_test.go
+++ b/api/internal/handler/helpers_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/enzyme/api/internal/auth"
 	"github.com/enzyme/api/internal/channel"
+	"github.com/enzyme/api/internal/config"
+	"github.com/enzyme/api/internal/email"
 	"github.com/enzyme/api/internal/emoji"
 	"github.com/enzyme/api/internal/file"
 	"github.com/enzyme/api/internal/linkpreview"
@@ -53,6 +55,8 @@ func testHandler(t *testing.T) (*Handler, *sql.DB) {
 
 	moderationRepo := moderation.NewRepository(db)
 
+	emailService, _ := email.NewService(config.EmailConfig{Enabled: false}, "http://localhost:8080")
+
 	h := New(Dependencies{
 		AuthService:         authService,
 		SessionStore:        sessionStore,
@@ -65,6 +69,7 @@ func testHandler(t *testing.T) (*Handler, *sql.DB) {
 		EmojiRepo:           emojiRepo,
 		ModerationRepo:      moderationRepo,
 		NotificationService: notifService,
+		EmailService:        emailService,
 		Hub:                 hub,
 		Signer:              signing.NewSigner("test-signing-secret"),
 		StoragePath:         t.TempDir(),
@@ -177,6 +182,8 @@ func testHandlerWithLinkPreviews(t *testing.T, httpClient *http.Client) (*Handle
 	lpFetcher := linkpreview.NewFetcherWithClient(lpRepo, httpClient)
 	moderationRepo := moderation.NewRepository(db)
 
+	emailService, _ := email.NewService(config.EmailConfig{Enabled: false}, "http://localhost:8080")
+
 	h := New(Dependencies{
 		AuthService:         authService,
 		SessionStore:        sessionStore,
@@ -191,6 +198,7 @@ func testHandlerWithLinkPreviews(t *testing.T, httpClient *http.Client) (*Handle
 		EmojiRepo:           emojiRepo,
 		ModerationRepo:      moderationRepo,
 		NotificationService: notifService,
+		EmailService:        emailService,
 		Hub:                 hub,
 		Signer:              signing.NewSigner("test-signing-secret"),
 		StoragePath:         t.TempDir(),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,12 @@ const ThreadsPage = lazy(() =>
 const ScheduledMessagesPage = lazy(() =>
   import('./pages/ScheduledMessagesPage').then((m) => ({ default: m.ScheduledMessagesPage })),
 );
+const ForgotPasswordPage = lazy(() =>
+  import('./pages/ForgotPasswordPage').then((m) => ({ default: m.ForgotPasswordPage })),
+);
+const ResetPasswordPage = lazy(() =>
+  import('./pages/ResetPasswordPage').then((m) => ({ default: m.ResetPasswordPage })),
+);
 
 function PageSpinner() {
   return (
@@ -45,6 +51,22 @@ function App() {
           {/* Public routes */}
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route
+            path="/forgot-password"
+            element={
+              <Suspense fallback={<PageSpinner />}>
+                <ForgotPasswordPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/reset-password"
+            element={
+              <Suspense fallback={<PageSpinner />}>
+                <ResetPasswordPage />
+              </Suspense>
+            }
+          />
           <Route
             path="/invites/:code"
             element={

--- a/apps/web/src/components/auth/ForgotPasswordForm.tsx
+++ b/apps/web/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,83 @@
+import { useState, type FormEvent } from 'react';
+import { Link } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { Button, Input } from '../ui';
+import { authApi, ApiError } from '../../api';
+
+export function ForgotPasswordForm() {
+  const [email, setEmail] = useState('');
+
+  const forgotPassword = useMutation({
+    mutationFn: (email: string) => authApi.forgotPassword(email),
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    forgotPassword.mutate(email);
+  };
+
+  if (forgotPassword.isSuccess) {
+    return (
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Check your email</h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            If an account exists for {email}, we sent a password reset link.
+          </p>
+        </div>
+
+        <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+          <Link to="/login" className="font-medium text-blue-600 hover:text-blue-700">
+            Back to sign in
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  const error =
+    forgotPassword.error instanceof ApiError
+      ? forgotPassword.error.message
+      : forgotPassword.error
+        ? 'An error occurred. Please try again.'
+        : null;
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="mb-8 text-center">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Forgot password?</h1>
+        <p className="mt-2 text-gray-600 dark:text-gray-400">
+          Enter your email and we'll send you a reset link
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+            {error}
+          </div>
+        )}
+
+        <Input
+          type="email"
+          label="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          isRequired
+          autoComplete="email"
+        />
+
+        <Button type="submit" className="w-full" isLoading={forgotPassword.isPending}>
+          Send reset link
+        </Button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-gray-600 dark:text-gray-400">
+        <Link to="/login" className="font-medium text-blue-600 hover:text-blue-700">
+          Back to sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -59,6 +59,15 @@ export function LoginForm() {
           autoComplete="current-password"
         />
 
+        <div className="text-right">
+          <Link
+            to="/forgot-password"
+            className="text-sm font-medium text-blue-600 hover:text-blue-700"
+          >
+            Forgot password?
+          </Link>
+        </div>
+
         <Button type="submit" className="w-full" isLoading={isLoggingIn}>
           Sign in
         </Button>

--- a/apps/web/src/components/auth/ResetPasswordForm.tsx
+++ b/apps/web/src/components/auth/ResetPasswordForm.tsx
@@ -1,0 +1,125 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { Button, Input } from '../ui';
+import { authApi, ApiError } from '../../api';
+
+export function ResetPasswordForm() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [validationError, setValidationError] = useState('');
+
+  const resetPassword = useMutation({
+    mutationFn: ({ token, password }: { token: string; password: string }) =>
+      authApi.resetPassword(token, password),
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setValidationError('');
+
+    if (!token) return;
+
+    if (password !== confirmPassword) {
+      setValidationError('Passwords do not match');
+      return;
+    }
+
+    if (password.length < 8) {
+      setValidationError('Password must be at least 8 characters');
+      return;
+    }
+
+    resetPassword.mutate({ token, password });
+  };
+
+  if (!token) {
+    return (
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Invalid reset link</h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            This password reset link is invalid or has expired.
+          </p>
+        </div>
+
+        <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+          <Link to="/forgot-password" className="font-medium text-blue-600 hover:text-blue-700">
+            Request a new reset link
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  if (resetPassword.isSuccess) {
+    return (
+      <div className="w-full max-w-md">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Password reset</h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            Your password has been reset successfully.
+          </p>
+        </div>
+
+        <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+          <Link to="/login" className="font-medium text-blue-600 hover:text-blue-700">
+            Sign in with your new password
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  const apiError =
+    resetPassword.error instanceof ApiError
+      ? resetPassword.error.message
+      : resetPassword.error
+        ? 'An error occurred. Please try again.'
+        : null;
+  const error = validationError || apiError;
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="mb-8 text-center">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Reset password</h1>
+        <p className="mt-2 text-gray-600 dark:text-gray-400">Enter your new password</p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+            {error}
+          </div>
+        )}
+
+        <Input
+          type="password"
+          label="New password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="At least 8 characters"
+          isRequired
+          autoComplete="new-password"
+        />
+
+        <Input
+          type="password"
+          label="Confirm password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          placeholder="Confirm your password"
+          isRequired
+          autoComplete="new-password"
+        />
+
+        <Button type="submit" className="w-full" isLoading={resetPassword.isPending}>
+          Reset password
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/index.ts
+++ b/apps/web/src/components/auth/index.ts
@@ -1,3 +1,5 @@
+export { ForgotPasswordForm } from './ForgotPasswordForm';
 export { LoginForm } from './LoginForm';
 export { RegisterForm } from './RegisterForm';
 export { RequireAuth } from './RequireAuth';
+export { ResetPasswordForm } from './ResetPasswordForm';

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,12 @@
+import { ForgotPasswordForm } from '../components/auth';
+import { usePageTitle } from '../hooks';
+
+export function ForgotPasswordPage() {
+  usePageTitle('Forgot password');
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+      <ForgotPasswordForm />
+    </div>
+  );
+}

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,12 @@
+import { ResetPasswordForm } from '../components/auth';
+import { usePageTitle } from '../hooks';
+
+export function ResetPasswordPage() {
+  usePageTitle('Reset password');
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
+      <ResetPasswordForm />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Wire the email service into the `ForgotPassword` handler so it sends the reset email when a valid token is created
- Add frontend UI: "Forgot password?" link on login, forgot password page, and reset password page
- Email is sent asynchronously to avoid blocking the response and to prevent timing-based email enumeration

## Changes

**Backend:**
- Add `emailService` dependency to Handler and wire in `app.go`
- `ForgotPassword` handler captures the token, logs errors from `CreatePasswordResetToken`, and sends the email in a background goroutine with a 30s timeout
- Move reset URL construction into `email.Service.SendPasswordReset` using `net/url` for safe encoding
- Add `TestForgotPassword` handler tests
- Add `EmailService` (no-op) to test helpers to prevent nil pointer panics

**Frontend:**
- `ForgotPasswordForm` — email input, submits via `useMutation`, shows confirmation on success
- `ResetPasswordForm` — password + confirm fields with client-side validation, reads token from URL search params
- `ForgotPasswordPage` / `ResetPasswordPage` — lightweight page wrappers
- Both pages lazy-loaded with `React.lazy` + `Suspense`
- "Forgot password?" link added to `LoginForm`

## Test plan

- [x] `make test` — all tests pass (Go + TypeScript)
- [x] `make lint` — no issues
- [x] `make format-check` — clean
- [ ] Manual: `/login` → click "Forgot password?" → lands on `/forgot-password`
- [ ] Manual: Enter email → submit → see "Check your email" confirmation
- [ ] Manual: Check API logs for reset URL in debug output → visit `/reset-password?token=...`
- [ ] Manual: Enter new password → submit → success → sign in with new password
- [ ] Manual: Error cases — mismatched passwords, short password, invalid token, missing token

Closes #133