### PR TITLE
Add "Mark as Read" to channel header dropdown

### DIFF
--- a/apps/web/src/pages/ChannelPage.tsx
+++ b/apps/web/src/pages/ChannelPage.tsx
@@ -14,6 +14,7 @@ import {
   BellIcon,
   LinkIcon,
   ChevronLeftIcon,
+  EnvelopeOpenIcon,
 } from '@heroicons/react/24/outline';
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid';
 import { Button as AriaButton } from 'react-aria-components';
@@ -390,6 +391,14 @@ export function ChannelPage() {
               >
                 Copy Link
               </MenuItem>
+              {channel.unread_count > 0 && (
+                <MenuItem
+                  onAction={() => markAsRead.mutate({ channelId: channel.id })}
+                  icon={<EnvelopeOpenIcon className="h-4 w-4" />}
+                >
+                  Mark as Read
+                </MenuItem>
+              )}
               {isChannel && isMember && (
                 <MenuItem
                   onAction={handleToggleMute}


### PR DESCRIPTION
## Summary
- Add a "Mark as Read" menu item to the channel header dropdown in `ChannelPage.tsx`
- Only shown when the channel has unread messages (`unread_count > 0`), matching the existing sidebar context menu behavior
- Uses the existing `useMarkChannelAsRead` hook already initialized in the component

## Test plan
- Open a channel that has unread messages
- Click the channel name dropdown — verify "Mark as Read" appears
- Click "Mark as Read" — verify the unread indicator clears
- Open a channel with no unreads — verify "Mark as Read" does not appear in the dropdown

Closes #126