### PR TITLE
Suppress message action bar flicker during scroll

### DIFF
--- a/apps/web/src/components/message/MessageItem.tsx
+++ b/apps/web/src/components/message/MessageItem.tsx
@@ -284,7 +284,9 @@ export function MessageItem({ message, channelId, channels, isAdmin }: MessageIt
       )}
       style={isDeleting ? { marginTop: 0, marginBottom: 0 } : undefined}
       onContextMenu={msgCtx.onContextMenu}
-      onMouseEnter={() => setShowActions(true)}
+      onPointerMove={() => {
+        if (!showActions) setShowActions(true);
+      }}
       onMouseLeave={() => {
         if (!showDropdown && !reactionPickerOpen && !msgCtx.isOpen) {
           setShowActions(false);

--- a/apps/web/src/components/message/SystemMessage.tsx
+++ b/apps/web/src/components/message/SystemMessage.tsx
@@ -112,7 +112,9 @@ export function SystemMessage({ message, channelId }: SystemMessageProps) {
         'hover:bg-gray-100 dark:hover:bg-gray-800',
         showDropdown && 'bg-gray-100 dark:bg-gray-800',
       )}
-      onMouseEnter={() => setShowActions(true)}
+      onPointerMove={() => {
+        if (!showActions) setShowActions(true);
+      }}
       onMouseLeave={() => {
         if (!showDropdown && !reactionPickerOpen) {
           setShowActions(false);


### PR DESCRIPTION
## Summary
- Replace `onMouseEnter` with `onPointerMove` in `MessageItem` and `SystemMessage` to show the action bar only on actual mouse movement
- `pointermove` doesn't fire when the pointer is stationary during scroll, so the action bar no longer flashes as messages scroll past the cursor — matching Slack's behavior
- Added a `!showActions` guard to avoid unnecessary state updates from frequent pointermove events

## Test plan
- Scroll through a busy channel — action bars should not flash on messages as they pass under the cursor
- Stop scrolling and move the mouse onto a message — action bar appears normally
- Hover a message, open emoji picker or dropdown, then scroll — action bar stays visible (popover guards still work)
- Verify thread panel messages still show action bars on hover

Closes #155