### PR TITLE
Set explicit TLS 1.2 minimum in manual TLS mode

### DIFF
--- a/api/internal/server/server.go
+++ b/api/internal/server/server.go
@@ -44,7 +44,8 @@ func New(host string, port int, handler http.Handler, tlsOpts TLSOptions, readTi
 		},
 	}
 
-	if tlsOpts.Mode == "auto" {
+	switch tlsOpts.Mode {
+	case "auto":
 		s.certManager = &autocert.Manager{
 			Prompt:     autocert.AcceptTOS,
 			HostPolicy: autocert.HostWhitelist(tlsOpts.Domain),
@@ -60,6 +61,10 @@ func New(host string, port int, handler http.Handler, tlsOpts TLSOptions, readTi
 			Handler:      s.certManager.HTTPHandler(nil),
 			ReadTimeout:  10 * time.Second,
 			WriteTimeout: 10 * time.Second,
+		}
+	case "manual":
+		s.httpServer.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
 		}
 	}
 

--- a/api/internal/server/server_test.go
+++ b/api/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"net/http"
 	"testing"
 	"time"
@@ -58,8 +59,11 @@ func TestNew_ModeManual(t *testing.T) {
 		KeyFile:  "/path/to/key.pem",
 	}, 30*time.Second, 60*time.Second, 120*time.Second)
 
-	if s.httpServer.TLSConfig != nil {
-		t.Fatal("expected no TLSConfig for mode manual (certs loaded from file)")
+	if s.httpServer.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be set for mode manual")
+	}
+	if s.httpServer.TLSConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatal("expected MinVersion TLS 1.2 for mode manual")
 	}
 	if s.certManager != nil {
 		t.Fatal("expected no certManager for mode manual")


### PR DESCRIPTION
## Summary
- Set `MinVersion: tls.VersionTLS12` on the TLS config when using manual TLS mode, matching the existing behavior in auto mode
- Converts the if/else chain to a switch statement per linter preference

## Test plan
- [x] Existing server tests updated and passing
- [x] Lint passes (staticcheck QF1003 resolved)
- [ ] Verify manual TLS mode still starts correctly with cert/key files

Closes #113