### PR TITLE
Gate email-dependent UI on SMTP configuration

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -286,13 +286,15 @@ func (a *App) Start(ctx context.Context) error {
 	}
 
 	s.Register(scheduler.Task{Name: "presence-check", Interval: 10 * time.Second, Fn: a.PresenceManager.CheckPresence})
-	s.Register(scheduler.Task{Name: "email-notifications", Interval: time.Minute, Fn: a.EmailWorker.ProcessPending})
 	s.Register(scheduler.Task{Name: "scheduled-messages", Interval: 30 * time.Second, Fn: a.ScheduledWorker.ProcessDue})
-	s.Register(scheduler.Task{Name: "password-reset-cleanup", Interval: 24 * time.Hour, Fn: a.passwordResetRepo.DeleteExpired})
 	s.Register(scheduler.Task{Name: "expired-ban-cleanup", Interval: time.Hour, Fn: a.moderationRepo.CleanupExpiredBans})
 	s.Register(scheduler.Task{Name: "sqlite-optimize", Interval: 24 * time.Hour, Fn: func(ctx context.Context) error { _, err := a.DB.Exec("PRAGMA optimize(0x10002)"); return err }})
 
-	s.Register(scheduler.Task{Name: "email-verification-cleanup", Interval: 24 * time.Hour, Fn: a.emailVerificationRepo.DeleteExpired})
+	if a.EmailService.IsEnabled() {
+		s.Register(scheduler.Task{Name: "email-notifications", Interval: time.Minute, Fn: a.EmailWorker.ProcessPending})
+		s.Register(scheduler.Task{Name: "password-reset-cleanup", Interval: 24 * time.Hour, Fn: a.passwordResetRepo.DeleteExpired})
+		s.Register(scheduler.Task{Name: "email-verification-cleanup", Interval: 24 * time.Hour, Fn: a.emailVerificationRepo.DeleteExpired})
+	}
 
 	s.Start(ctx)
 

--- a/api/internal/email/service.go
+++ b/api/internal/email/service.go
@@ -47,6 +47,18 @@ func (s *Service) IsEnabled() bool {
 	return s.enabled
 }
 
+// NewTestService creates an email service for testing with a NoOpSender.
+// Use enabled=true to test email-enabled code paths without real SMTP.
+func NewTestService(enabled bool, publicURL string) *Service {
+	templates, _ := template.ParseFS(templateFS, "templates/*.html", "templates/*.txt")
+	return &Service{
+		sender:    &NoOpSender{},
+		templates: templates,
+		publicURL: publicURL,
+		enabled:   enabled,
+	}
+}
+
 type InviteEmailData struct {
 	WorkspaceName string
 	InviterName   string

--- a/api/internal/handler/auth.go
+++ b/api/internal/handler/auth.go
@@ -47,18 +47,21 @@ func (h *Handler) Register(ctx context.Context, request openapi.RegisterRequestO
 		return nil, err
 	}
 
-	// Create verification token synchronously, send email async
-	verifyToken, err := h.authService.CreateEmailVerificationToken(ctx, u.ID)
-	if err != nil {
-		slog.Error("failed to create email verification token", "user_id", u.ID, "error", err)
-	} else {
-		go func() {
-			sendCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			if err := h.emailService.SendEmailVerification(sendCtx, u.Email, verifyToken); err != nil {
-				slog.Error("failed to send verification email", "user_id", u.ID, "error", err)
-			}
-		}()
+	// Verification email is best-effort; registration succeeds regardless of email config.
+	// When email is later enabled, unverified users will see the verification banner.
+	if h.emailService.IsEnabled() {
+		verifyToken, err := h.authService.CreateEmailVerificationToken(ctx, u.ID)
+		if err != nil {
+			slog.Error("failed to create email verification token", "user_id", u.ID, "error", err)
+		} else {
+			go func() {
+				sendCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				if err := h.emailService.SendEmailVerification(sendCtx, u.Email, verifyToken); err != nil {
+					slog.Error("failed to send verification email", "user_id", u.ID, "error", err)
+				}
+			}()
+		}
 	}
 
 	return openapi.Register200JSONResponse{
@@ -168,6 +171,12 @@ func (h *Handler) GetMe(ctx context.Context, request openapi.GetMeRequestObject)
 
 // ForgotPassword handles password reset requests
 func (h *Handler) ForgotPassword(ctx context.Context, request openapi.ForgotPasswordRequestObject) (openapi.ForgotPasswordResponseObject, error) {
+	if !h.emailService.IsEnabled() {
+		return openapi.ForgotPassword400JSONResponse{
+			BadRequestJSONResponse: badRequestResponse("EMAIL_NOT_ENABLED", "Email is not configured on this server"),
+		}, nil
+	}
+
 	token, err := h.authService.CreatePasswordResetToken(ctx, string(request.Body.Email))
 	if err != nil {
 		slog.Error("failed to create password reset token", "error", err)
@@ -236,6 +245,12 @@ func (h *Handler) ResendVerification(ctx context.Context, request openapi.Resend
 	if userID == "" {
 		return openapi.ResendVerification401JSONResponse{
 			UnauthorizedJSONResponse: openapi.UnauthorizedJSONResponse(newErrorResponse(ErrCodeNotAuthenticated, "Not authenticated")),
+		}, nil
+	}
+
+	if !h.emailService.IsEnabled() {
+		return openapi.ResendVerification400JSONResponse{
+			BadRequestJSONResponse: badRequestResponse("EMAIL_NOT_ENABLED", "Email is not configured on this server"),
 		}, nil
 	}
 

--- a/api/internal/handler/auth_test.go
+++ b/api/internal/handler/auth_test.go
@@ -71,7 +71,7 @@ func TestUserToAPI_NilOptionalFields(t *testing.T) {
 }
 
 func TestForgotPassword(t *testing.T) {
-	h, db := testHandler(t)
+	h, db := testHandlerWithEmail(t)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -102,6 +102,36 @@ func TestForgotPassword(t *testing.T) {
 				t.Error("expected success=true")
 			}
 		})
+	}
+}
+
+func TestForgotPassword_EmailDisabled(t *testing.T) {
+	h, _ := testHandler(t)
+	ctx := context.Background()
+
+	body := openapi.ForgotPasswordJSONRequestBody{
+		Email: openapi_types.Email("test@example.com"),
+	}
+	resp, err := h.ForgotPassword(ctx, openapi.ForgotPasswordRequestObject{Body: &body})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(openapi.ForgotPassword400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
+	}
+}
+
+func TestResendVerification_EmailDisabled(t *testing.T) {
+	h, db := testHandler(t)
+	u := testutil.CreateTestUser(t, db, "test@example.com", "Test")
+	ctx := ctxWithUser(t, h, u.ID)
+
+	resp, err := h.ResendVerification(ctx, openapi.ResendVerificationRequestObject{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := resp.(openapi.ResendVerification400JSONResponse); !ok {
+		t.Fatalf("expected 400 response, got %T", resp)
 	}
 }
 

--- a/api/internal/handler/helpers_test.go
+++ b/api/internal/handler/helpers_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/enzyme/api/internal/auth"
 	"github.com/enzyme/api/internal/channel"
-	"github.com/enzyme/api/internal/config"
 	"github.com/enzyme/api/internal/email"
 	"github.com/enzyme/api/internal/emoji"
 	"github.com/enzyme/api/internal/file"
@@ -56,7 +55,7 @@ func testHandler(t *testing.T) (*Handler, *sql.DB) {
 
 	moderationRepo := moderation.NewRepository(db)
 
-	emailService, _ := email.NewService(config.EmailConfig{Enabled: false}, "http://localhost:8080")
+	emailService := email.NewTestService(false, "http://localhost:8080")
 
 	h := New(Dependencies{
 		AuthService:         authService,
@@ -154,6 +153,15 @@ func createFileAttachment(t *testing.T, db *sql.DB, channelID, userID string) st
 	return id
 }
 
+// testHandlerWithEmail creates a Handler with email enabled (using NoOpSender)
+// for testing email-dependent code paths without real SMTP.
+func testHandlerWithEmail(t *testing.T) (*Handler, *sql.DB) {
+	t.Helper()
+	h, db := testHandler(t)
+	h.emailService = email.NewTestService(true, "http://localhost:8080")
+	return h, db
+}
+
 // testHandlerWithLinkPreviews creates a Handler with link preview support wired in.
 // The httpClient is used by the fetcher (pass a test server's client).
 func testHandlerWithLinkPreviews(t *testing.T, httpClient *http.Client) (*Handler, *sql.DB) {
@@ -184,7 +192,7 @@ func testHandlerWithLinkPreviews(t *testing.T, httpClient *http.Client) (*Handle
 	lpFetcher := linkpreview.NewFetcherWithClient(lpRepo, httpClient)
 	moderationRepo := moderation.NewRepository(db)
 
-	emailService, _ := email.NewService(config.EmailConfig{Enabled: false}, "http://localhost:8080")
+	emailService := email.NewTestService(false, "http://localhost:8080")
 
 	h := New(Dependencies{
 		AuthService:         authService,

--- a/api/internal/handler/server.go
+++ b/api/internal/handler/server.go
@@ -8,7 +8,9 @@ import (
 )
 
 func (h *Handler) GetServerInfo(_ context.Context, _ openapi.GetServerInfoRequestObject) (openapi.GetServerInfoResponseObject, error) {
+	emailEnabled := h.emailService.IsEnabled()
 	return openapi.GetServerInfo200JSONResponse{
-		Version: version.Version,
+		Version:      version.Version,
+		EmailEnabled: &emailEnabled,
 	}, nil
 }

--- a/api/internal/handler/server_test.go
+++ b/api/internal/handler/server_test.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"github.com/enzyme/api/internal/email"
 	"github.com/enzyme/api/internal/openapi"
 	"github.com/enzyme/api/internal/version"
 )
 
 func TestGetServerInfo(t *testing.T) {
-	h := &Handler{}
+	h := &Handler{emailService: email.NewTestService(false, "")}
 
 	resp, err := h.GetServerInfo(context.Background(), openapi.GetServerInfoRequestObject{})
 	if err != nil {
@@ -23,5 +24,23 @@ func TestGetServerInfo(t *testing.T) {
 
 	if jsonResp.Version != version.Version {
 		t.Errorf("expected version %q, got %q", version.Version, jsonResp.Version)
+	}
+
+	if jsonResp.EmailEnabled == nil || *jsonResp.EmailEnabled != false {
+		t.Error("expected email_enabled to be false")
+	}
+}
+
+func TestGetServerInfo_EmailEnabled(t *testing.T) {
+	h := &Handler{emailService: email.NewTestService(true, "")}
+
+	resp, err := h.GetServerInfo(context.Background(), openapi.GetServerInfoRequestObject{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	jsonResp := resp.(openapi.GetServerInfo200JSONResponse)
+	if jsonResp.EmailEnabled == nil || *jsonResp.EmailEnabled != true {
+		t.Error("expected email_enabled to be true")
 	}
 }

--- a/api/internal/openapi/server.gen.go
+++ b/api/internal/openapi/server.gen.go
@@ -535,7 +535,8 @@ type SendMessageInput struct {
 
 // ServerInfo defines model for ServerInfo.
 type ServerInfo struct {
-	Version string `json:"version"`
+	EmailEnabled *bool  `json:"email_enabled,omitempty"`
+	Version      string `json:"version"`
 }
 
 // SignedUrl defines model for SignedUrl.
@@ -4630,6 +4631,15 @@ type ForgotPassword200JSONResponse struct {
 func (response ForgotPassword200JSONResponse) VisitForgotPasswordResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ForgotPassword400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response ForgotPassword400JSONResponse) VisitForgotPasswordResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -129,6 +129,8 @@ paths:
                     type: boolean
                   message:
                     type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
 
   /auth/reset-password:
     post:
@@ -3322,6 +3324,8 @@ components:
       properties:
         version:
           type: string
+        email_enabled:
+          type: boolean
 
     SuccessResponse:
       type: object

--- a/apps/web/src/api/index.ts
+++ b/apps/web/src/api/index.ts
@@ -1,4 +1,5 @@
 export { authApi } from './auth';
+export { serverApi } from './server';
 export { workspacesApi } from './workspaces';
 export { channelsApi } from './channels';
 export { messagesApi } from './messages';

--- a/apps/web/src/api/server.ts
+++ b/apps/web/src/api/server.ts
@@ -1,0 +1,5 @@
+import { get, type ServerInfo } from '@enzyme/api-client';
+
+export const serverApi = {
+  getServerInfo: () => get<ServerInfo>('/server-info'),
+};

--- a/apps/web/src/components/auth/LoginForm.test.tsx
+++ b/apps/web/src/components/auth/LoginForm.test.tsx
@@ -28,6 +28,9 @@ vi.mock('../../api/auth', () => ({
 
 vi.mock('../../api', () => ({
   ApiError: MockApiError,
+  serverApi: {
+    getServerInfo: vi.fn().mockResolvedValue({ version: '0.0.0', email_enabled: true }),
+  },
 }));
 
 // Import after mocks are set up

--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Input } from '../ui';
-import { useAuth } from '../../hooks';
+import { useAuth, useServerInfo } from '../../hooks';
 import { ApiError } from '../../api';
 
 export function LoginForm() {
@@ -9,6 +9,7 @@ export function LoginForm() {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const { login, isLoggingIn } = useAuth();
+  const { emailEnabled } = useServerInfo();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -59,14 +60,16 @@ export function LoginForm() {
           autoComplete="current-password"
         />
 
-        <div className="text-right">
-          <Link
-            to="/forgot-password"
-            className="text-sm font-medium text-blue-600 hover:text-blue-700"
-          >
-            Forgot password?
-          </Link>
-        </div>
+        {emailEnabled && (
+          <div className="text-right">
+            <Link
+              to="/forgot-password"
+              className="text-sm font-medium text-blue-600 hover:text-blue-700"
+            >
+              Forgot password?
+            </Link>
+          </div>
+        )}
 
         <Button type="submit" className="w-full" isLoading={isLoggingIn}>
           Sign in

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -12,7 +12,7 @@ import {
 } from '../settings/WorkspaceSettingsModal';
 import { BanScreen } from '../moderation/BanModal';
 import { EmailVerificationBanner } from '../auth/EmailVerificationBanner';
-import { useSSE, useAuth, useIsMobile, useMobileNav } from '../../hooks';
+import { useSSE, useAuth, useServerInfo, useIsMobile, useMobileNav } from '../../hooks';
 import { useThreadPanel, useProfilePanel } from '../../hooks/usePanel';
 import { useSidebar } from '../../hooks/useSidebar';
 import { useResizableWidth } from '../../hooks/useResizableWidth';
@@ -32,6 +32,7 @@ export function AppLayout() {
   const { workspaceId, channelId } = useParams<{ workspaceId: string; channelId: string }>();
   const { isReconnecting } = useSSE(workspaceId);
   const { user, workspaces } = useAuth();
+  const { emailEnabled } = useServerInfo();
   const currentWorkspace = workspaces?.find((ws) => ws.id === workspaceId);
   const { threadId } = useThreadPanel();
   const { profileUserId } = useProfilePanel();
@@ -113,7 +114,7 @@ export function AppLayout() {
   return (
     <div className="flex h-screen flex-col bg-white dark:bg-gray-900">
       {/* Email Verification Banner */}
-      {!user?.email_verified_at && <EmailVerificationBanner />}
+      {emailEnabled && !user?.email_verified_at && <EmailVerificationBanner />}
 
       {/* Connection Status - full width */}
       {isReconnecting && workspaceId && (

--- a/apps/web/src/hooks/index.ts
+++ b/apps/web/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAuth } from './useAuth';
+export { useServerInfo } from './useServerInfo';
 export {
   useWorkspace,
   useWorkspaceMembers,

--- a/apps/web/src/hooks/useServerInfo.ts
+++ b/apps/web/src/hooks/useServerInfo.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { serverApi } from '../api';
+
+export function useServerInfo() {
+  const { data } = useQuery({
+    queryKey: ['server-info'],
+    queryFn: serverApi.getServerInfo,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  return {
+    emailEnabled: data?.email_enabled ?? true,
+  };
+}

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,12 +1,31 @@
+import { Link } from 'react-router-dom';
 import { ForgotPasswordForm } from '../components/auth';
-import { usePageTitle } from '../hooks';
+import { usePageTitle, useServerInfo } from '../hooks';
 
 export function ForgotPasswordPage() {
   usePageTitle('Forgot password');
+  const { emailEnabled } = useServerInfo();
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 dark:bg-gray-900">
-      <ForgotPasswordForm />
+      {emailEnabled ? (
+        <ForgotPasswordForm />
+      ) : (
+        <div className="w-full max-w-md text-center">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Password reset unavailable
+          </h1>
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            Email is not configured on this server. Contact your administrator to reset your
+            password.
+          </p>
+          <p className="mt-6 text-sm text-gray-600 dark:text-gray-400">
+            <Link to="/login" className="font-medium text-blue-600 hover:text-blue-700">
+              Back to sign in
+            </Link>
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,7 @@ Enzyme uses SQLite in WAL mode. No external database server is needed. See [Scal
 
 ## Email
 
-Email is optional. When disabled, features like password reset and notification emails won't be available, but invite links will still work.
+Email is optional. When disabled, password reset, email verification, and notification digest features are unavailable and their UI is hidden. Invite links will still work.
 
 | Key              | Env Var                 | CLI Flag          | Default | Description                                                  |
 | ---------------- | ----------------------- | ----------------- | ------- | ------------------------------------------------------------ |

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,7 +41,7 @@ Passwords are hashed with bcrypt at cost 12 (configurable via `auth.bcrypt_cost`
 
 ### Password Reset
 
-Reset tokens are 32 bytes from `crypto/rand` (hex-encoded), expire after 1 hour, and are single-use. The forgot-password endpoint returns a success response regardless of whether the email exists, preventing email enumeration.
+Reset tokens are 32 bytes from `crypto/rand` (hex-encoded), expire after 1 hour, and are single-use. The forgot-password endpoint returns a success response regardless of whether the email exists, preventing email enumeration. When email is not configured, the endpoint returns a 400 error.
 
 ### Rate Limiting
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -170,7 +170,7 @@ server:
 
 ## Email Setup
 
-Email is optional but enables password resets, workspace invites, and notification digests. Without email, users can only be invited via shareable invite links.
+Email is optional but enables password resets, email verification, workspace invites, and notification digests. Without email, the password reset and verification UI is hidden, and users can only be invited via shareable invite links.
 
 ```yaml
 email:

--- a/packages/api-client/generated/schema.ts
+++ b/packages/api-client/generated/schema.ts
@@ -1817,6 +1817,7 @@ export interface components {
         };
         ServerInfo: {
             version: string;
+            email_enabled?: boolean;
         };
         SuccessResponse: {
             success: boolean;
@@ -2497,6 +2498,7 @@ export interface operations {
                     };
                 };
             };
+            400: components["responses"]["BadRequest"];
         };
     };
     resetPassword: {

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -33,6 +33,9 @@ export type Attachment = components['schemas']['Attachment'];
 export type LinkPreview = components['schemas']['LinkPreview'];
 export type ThreadParticipant = components['schemas']['ThreadParticipant'];
 
+// Server types
+export type ServerInfo = components['schemas']['ServerInfo'];
+
 // API types
 export type ApiError = components['schemas']['ApiError'];
 export type ApiErrorResponse = components['schemas']['ApiErrorResponse'];


### PR DESCRIPTION
## Summary
- Expose `email_enabled` via the `/server-info` endpoint so clients can detect SMTP availability
- Hide forgot-password link, email verification banner, and show an "unavailable" message on the forgot-password page when email is disabled
- Return 400 from `forgot-password` and `resend-verification` endpoints when SMTP is not configured
- Skip email-related scheduler tasks (digest, password-reset cleanup, verification cleanup) when email is disabled
- Users registered without email remain unverified — enabling SMTP later naturally prompts verification

## Test plan
- Start server without SMTP: forgot-password link hidden, verification banner hidden, forgot-password page shows unavailable message, `POST /auth/forgot-password` returns 400
- Start server with SMTP: all email flows work normally
- `make test` passes

Closes #151