### PR TITLE
Fix right panel drag-to-resize on desktop

### DIFF
--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -185,7 +185,7 @@ export function AppLayout() {
                 <div
                   className={cn(
                     'flex-shrink-0',
-                    'md:!block',
+                    'md:!block md:!flex-none',
                     activePanel === 'thread' || activePanel === 'profile'
                       ? 'flex min-h-0 flex-1 flex-col'
                       : 'hidden',


### PR DESCRIPTION
## Summary
- When the thread/profile panel is open, `activePanel` becomes `'thread'` or `'profile'`, applying `flex-1` (designed for mobile full-screen layout) to the right panel container
- On desktop, `flex-basis: 0%` from `flex-1` overrides the inline `width` style set by the resize hook, so dragging the divider has no visible effect
- Adding `md:!flex-none` resets flex to `0 0 auto` on desktop, allowing the inline width to be respected

## Test plan
- Open a thread or profile panel on desktop
- Hover over the left edge of the panel — cursor should change to `col-resize`
- Drag the divider left/right — panel should resize smoothly
- Release — width should persist across panel close/reopen
- Verify mobile layout still works (panel fills screen when active)