### PR TITLE
Redact sensitive tokens from debug log output

### DIFF
--- a/api/internal/email/service.go
+++ b/api/internal/email/service.go
@@ -82,7 +82,7 @@ func (s *Service) SendPasswordReset(ctx context.Context, to string, token string
 	resetURL := s.publicURL + "/reset-password?" + url.Values{"token": {token}}.Encode()
 
 	if !s.enabled {
-		slog.Debug("would send password reset", "component", "email", "to", to, "url", resetURL)
+		slog.Debug("would send password reset", "component", "email", "to", to)
 		return nil
 	}
 
@@ -98,7 +98,7 @@ func (s *Service) SendEmailVerification(ctx context.Context, to string, token st
 	verifyURL := s.publicURL + "/verify-email?" + url.Values{"token": {token}}.Encode()
 
 	if !s.enabled {
-		slog.Debug("would send email verification", "component", "email", "to", to, "url", verifyURL)
+		slog.Debug("would send email verification", "component", "email", "to", to)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Remove password reset token URL from `slog.Debug` in `SendPasswordReset`
- Remove email verification token URL from `slog.Debug` in `SendEmailVerification`
- Both log lines still indicate an email would have been sent and to whom, preserving debuggability without leaking secrets

## Test plan
- [ ] Run `make dev` with email disabled, trigger password reset and email verification flows, confirm logs no longer contain tokens
- [ ] Verify the debug log messages still appear with component and recipient info