### PR TITLE
Add missing rows.Err() checks after SQL iteration

### DIFF
--- a/api/internal/presence/manager.go
+++ b/api/internal/presence/manager.go
@@ -3,6 +3,7 @@ package presence
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -83,6 +84,9 @@ func (m *Manager) loadFromDB() {
 			m.presence[p.WorkspaceID] = make(map[string]*UserPresence)
 		}
 		m.presence[p.WorkspaceID][p.UserID] = &p
+	}
+	if err := rows.Err(); err != nil {
+		slog.Error("error iterating presence rows", "error", err)
 	}
 }
 

--- a/api/internal/sse/hub.go
+++ b/api/internal/sse/hub.go
@@ -285,6 +285,9 @@ func (h *Hub) getChannelMembers(channelID string) map[string]bool {
 					members[userID] = true
 				}
 			}
+			if err := rows.Err(); err != nil {
+				slog.Error("error iterating channel members", "channel_id", channelID, "error", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `rows.Err()` checks after `rows.Next()` loops in `presence/manager.go` and `sse/hub.go` to catch iteration errors (context cancellation, connection resets) that were previously silently swallowed

## Test plan
- `make test` passes
- `make lint` passes
- Verified both call sites now log errors via `slog.Error` with relevant context

Closes #185