### PR TITLE
Add membership checks to typing endpoints

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -163,7 +163,7 @@ func New(cfg *config.Config) (*App, error) {
 	cfg.Server.PublicURL = strings.TrimRight(cfg.Server.PublicURL, "/")
 
 	// Initialize SSE handler (kept separate as it requires streaming)
-	sseHandler := sse.NewHandler(hub, workspaceRepo, cfg.SSE.HeartbeatInterval, cfg.SSE.ClientBufferSize)
+	sseHandler := sse.NewHandler(hub, workspaceRepo, channelRepo, cfg.SSE.HeartbeatInterval, cfg.SSE.ClientBufferSize)
 
 	// Initialize main handler implementing StrictServerInterface
 	h := handler.New(handler.Dependencies{

--- a/api/internal/sse/handler.go
+++ b/api/internal/sse/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/enzyme/api/internal/auth"
+	"github.com/enzyme/api/internal/channel"
 	"github.com/enzyme/api/internal/openapi"
 	"github.com/enzyme/api/internal/workspace"
 	"github.com/go-chi/chi/v5"
@@ -17,14 +18,16 @@ import (
 type Handler struct {
 	hub               *Hub
 	workspaceRepo     *workspace.Repository
+	channelRepo       *channel.Repository
 	heartbeatInterval time.Duration
 	clientBufferSize  int
 }
 
-func NewHandler(hub *Hub, workspaceRepo *workspace.Repository, heartbeatInterval time.Duration, clientBufferSize int) *Handler {
+func NewHandler(hub *Hub, workspaceRepo *workspace.Repository, channelRepo *channel.Repository, heartbeatInterval time.Duration, clientBufferSize int) *Handler {
 	return &Handler{
 		hub:               hub,
 		workspaceRepo:     workspaceRepo,
+		channelRepo:       channelRepo,
 		heartbeatInterval: heartbeatInterval,
 		clientBufferSize:  clientBufferSize,
 	}
@@ -131,13 +134,69 @@ type TypingInput struct {
 	ChannelID string `json:"channel_id"`
 }
 
+// checkTypingAccess verifies workspace membership and channel access for typing endpoints.
+// Returns the decoded input and true if access is granted; writes an error response and returns false otherwise.
+func (h *Handler) checkTypingAccess(w http.ResponseWriter, r *http.Request, workspaceID, userID string) (TypingInput, bool) {
+	var input TypingInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid request body")
+		return input, false
+	}
+
+	if input.ChannelID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "channel_id is required")
+		return input, false
+	}
+
+	// Check workspace membership
+	_, err := h.workspaceRepo.GetMembership(r.Context(), userID, workspaceID)
+	if err != nil {
+		if errors.Is(err, workspace.ErrNotAMember) {
+			writeError(w, http.StatusForbidden, "NOT_A_MEMBER", "Not a member of this workspace")
+			return input, false
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Internal error")
+		return input, false
+	}
+
+	// Verify channel belongs to this workspace
+	ch, err := h.channelRepo.GetByID(r.Context(), input.ChannelID)
+	if err != nil {
+		if errors.Is(err, channel.ErrChannelNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "Channel not found")
+			return input, false
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Internal error")
+		return input, false
+	}
+	if ch.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Channel not found")
+		return input, false
+	}
+
+	// Check channel membership (public channels allow any workspace member)
+	_, err = h.channelRepo.GetMembership(r.Context(), userID, input.ChannelID)
+	if err != nil {
+		if errors.Is(err, channel.ErrNotChannelMember) {
+			if ch.Type != channel.TypePublic {
+				writeError(w, http.StatusForbidden, "NOT_A_MEMBER", "Not a member of this channel")
+				return input, false
+			}
+		} else {
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Internal error")
+			return input, false
+		}
+	}
+
+	return input, true
+}
+
 func (h *Handler) StartTyping(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "wid")
 	userID := auth.GetUserID(r.Context())
 
-	var input TypingInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid request body")
+	input, ok := h.checkTypingAccess(w, r, workspaceID, userID)
+	if !ok {
 		return
 	}
 
@@ -155,9 +214,8 @@ func (h *Handler) StopTyping(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "wid")
 	userID := auth.GetUserID(r.Context())
 
-	var input TypingInput
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid request body")
+	input, ok := h.checkTypingAccess(w, r, workspaceID, userID)
+	if !ok {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- **Security fix**: `StartTyping` and `StopTyping` SSE handlers now verify workspace membership, channel-workspace binding, and channel membership before broadcasting typing indicators
- Validates that the `channel_id` in the request body belongs to the workspace in the URL, preventing cross-workspace typing injection
- Allows workspace members to type in public channels without explicit channel membership, matching the existing message handler pattern
- Extracts a shared `checkTypingAccess` helper to avoid duplicating the auth logic across both handlers

## Test plan
- `make lint` and `make test` pass
- Verify typing indicators still work for channel members in normal usage
- Verify a workspace member can show typing in a public channel they haven't joined
- Verify a user cannot broadcast typing into a workspace they don't belong to (expect 403)
- Verify a user cannot reference a channel from another workspace (expect 404)
- Verify an empty `channel_id` returns 400

Closes #183