### PR TITLE
Fix review followups for SSE hub and presence manager

### DIFF
--- a/api/internal/presence/manager.go
+++ b/api/internal/presence/manager.go
@@ -123,7 +123,6 @@ func (m *Manager) SetOnline(workspaceID, userID string) {
 
 func (m *Manager) SetOffline(workspaceID, userID string) {
 	now := time.Now().UTC()
-	var shouldBroadcast bool
 
 	m.mu.Lock()
 	if m.presence[workspaceID] == nil {
@@ -143,14 +142,10 @@ func (m *Manager) SetOffline(workspaceID, userID string) {
 		Status:      StatusOffline,
 		LastSeenAt:  now,
 	}
-	shouldBroadcast = true
 	m.mu.Unlock()
 
 	m.persistPresence(context.Background(), workspaceID, userID, StatusOffline, now)
-
-	if shouldBroadcast {
-		m.broadcastPresenceChange(workspaceID, userID, openapi.Offline)
-	}
+	m.broadcastPresenceChange(workspaceID, userID, openapi.Offline)
 }
 
 func (m *Manager) SetStatus(workspaceID, userID, status string) {
@@ -220,25 +215,41 @@ type presenceChange struct {
 
 func (m *Manager) checkPresence(ctx context.Context) {
 	now := time.Now().UTC()
-	var offlineChanges []presenceChange
 
-	m.mu.Lock()
+	// Snapshot candidates under read lock — no calls into hub while holding mu.
+	type candidate struct {
+		workspaceID, userID string
+		lastSeenAt          time.Time
+	}
+	var candidates []candidate
+
+	m.mu.RLock()
 	for workspaceID, workspace := range m.presence {
 		for userID, p := range workspace {
-			if p.Status == StatusOffline {
-				continue
+			if p.Status != StatusOffline {
+				candidates = append(candidates, candidate{workspaceID, userID, p.LastSeenAt})
 			}
+		}
+	}
+	m.mu.RUnlock()
 
-			// Check if user is still connected via SSE
-			isConnected := m.hub != nil && m.hub.IsUserConnected(workspaceID, userID)
+	// Check connectivity without holding any presence lock.
+	var offlineChanges []presenceChange
+	for _, c := range candidates {
+		if now.Sub(c.lastSeenAt) <= OfflineTimeout {
+			continue
+		}
+		if m.hub != nil && m.hub.IsUserConnected(c.workspaceID, c.userID) {
+			continue
+		}
+		offlineChanges = append(offlineChanges, presenceChange{c.workspaceID, c.userID})
+	}
 
-			if !isConnected {
-				// User disconnected - mark offline after timeout
-				if now.Sub(p.LastSeenAt) > OfflineTimeout {
-					p.Status = StatusOffline
-					offlineChanges = append(offlineChanges, presenceChange{workspaceID, userID})
-				}
-			}
+	// Apply status changes under write lock.
+	m.mu.Lock()
+	for _, c := range offlineChanges {
+		if p, ok := m.presence[c.workspaceID][c.userID]; ok && p.Status != StatusOffline {
+			p.Status = StatusOffline
 		}
 	}
 	m.mu.Unlock()

--- a/api/internal/sse/hub.go
+++ b/api/internal/sse/hub.go
@@ -338,7 +338,15 @@ func (h *Hub) runStoreLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			// Drain remaining queued events before exiting
+			for {
+				select {
+				case req := <-h.storeQueue:
+					h.storeEvent(req.workspaceID, req.event)
+				default:
+					return
+				}
+			}
 		case req := <-h.storeQueue:
 			h.storeEvent(req.workspaceID, req.event)
 		}


### PR DESCRIPTION
## Summary
- Drain buffered events in `runStoreLoop` on context cancellation instead of silently dropping them, keeping SSE replay complete across server restarts
- Refactor `checkPresence` to snapshot candidates under `RLock` and check hub connectivity without holding the presence mutex, fully eliminating the `Manager.mu → Hub.mu` lock ordering that #190 intended to remove
- Remove dead `shouldBroadcast` conditional in `SetOffline`

## Test plan
- `make lint` — 0 issues
- `make test` — all Go tests and 475 frontend tests pass
- Verify presence indicators still work: open two browser sessions, confirm online/offline transitions broadcast correctly
- Verify SSE reconnection replay: disconnect and reconnect a client, confirm no events are lost