### PR TITLE
Add pluggable TokenStorage interface to @enzyme/api-client

### DIFF
--- a/apps/web/src/components/auth/RequireAuth.test.tsx
+++ b/apps/web/src/components/auth/RequireAuth.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@enzyme/api-client', async (importOriginal) => {
 
 // Import after mocks are set up
 import { RequireAuth } from './RequireAuth';
+import { setAuthToken } from '@enzyme/api-client';
 
 function TestApp() {
   return (
@@ -39,8 +40,8 @@ function TestApp() {
 describe('RequireAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Set a token in localStorage so the auth query is enabled
-    localStorage.setItem('enzyme_auth_token', 'test-token');
+    // Set a token so the auth query is enabled
+    setAuthToken('test-token');
   });
 
   it('shows loading spinner while checking auth', async () => {

--- a/apps/web/src/hooks/useAuth.test.tsx
+++ b/apps/web/src/hooks/useAuth.test.tsx
@@ -30,11 +30,13 @@ vi.mock('@enzyme/api-client', async (importOriginal) => {
     },
     setAuthToken: vi.fn(),
     getAuthToken: vi.fn(),
+    setTokenStorage: vi.fn(),
   };
 });
 
 // Import after mocks
 import { useAuth } from './useAuth';
+import { getAuthToken } from '@enzyme/api-client';
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -51,8 +53,8 @@ function createWrapper() {
 describe('useAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Set a token in localStorage so the query is enabled
-    localStorage.setItem('enzyme_auth_token', 'test-token');
+    // Mock getAuthToken to return a token so the query is enabled
+    vi.mocked(getAuthToken).mockReturnValue('test-token');
   });
 
   it('returns loading state initially', () => {

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -4,6 +4,8 @@ import {
   authApi,
   ApiError,
   setAuthToken,
+  getAuthToken,
+  setTokenStorage,
   type LoginInput,
   type RegisterInput,
   type User,
@@ -12,23 +14,12 @@ import {
 
 const TOKEN_KEY = 'enzyme_auth_token';
 
-function loadToken(): void {
-  const token = localStorage.getItem(TOKEN_KEY);
-  setAuthToken(token);
-}
-
-function saveToken(token: string): void {
-  localStorage.setItem(TOKEN_KEY, token);
-  setAuthToken(token);
-}
-
-function clearToken(): void {
-  localStorage.removeItem(TOKEN_KEY);
-  setAuthToken(null);
-}
-
-// Load token from localStorage on module load
-loadToken();
+// Plug in localStorage-backed persistence at module load
+setTokenStorage({
+  get: () => localStorage.getItem(TOKEN_KEY),
+  set: (token) => localStorage.setItem(TOKEN_KEY, token),
+  remove: () => localStorage.removeItem(TOKEN_KEY),
+});
 
 export function useAuth() {
   const queryClient = useQueryClient();
@@ -42,7 +33,7 @@ export function useAuth() {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-    enabled: !!localStorage.getItem(TOKEN_KEY),
+    enabled: !!getAuthToken(),
   });
 
   // 401 error means not authenticated, not an error state
@@ -51,14 +42,14 @@ export function useAuth() {
   // Clear token on 401 from /auth/me
   useEffect(() => {
     if (isAuthError) {
-      clearToken();
+      setAuthToken(null);
     }
   }, [isAuthError]);
 
   const loginMutation = useMutation({
     mutationFn: (input: LoginInput) => authApi.login(input),
     onSuccess: (data) => {
-      saveToken(data.token);
+      setAuthToken(data.token);
       queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
     },
   });
@@ -66,7 +57,7 @@ export function useAuth() {
   const registerMutation = useMutation({
     mutationFn: (input: RegisterInput) => authApi.register(input),
     onSuccess: (data) => {
-      saveToken(data.token);
+      setAuthToken(data.token);
       queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
     },
   });
@@ -74,7 +65,7 @@ export function useAuth() {
   const logoutMutation = useMutation({
     mutationFn: authApi.logout,
     onSuccess: () => {
-      clearToken();
+      setAuthToken(null);
       queryClient.clear();
     },
   });
@@ -82,7 +73,7 @@ export function useAuth() {
   return {
     user: data?.user as User | undefined,
     workspaces: data?.workspaces as WorkspaceSummary[] | undefined,
-    isLoading: !isFetched && !!localStorage.getItem(TOKEN_KEY),
+    isLoading: !isFetched && !!getAuthToken(),
     isAuthenticated: !!data?.user,
     error: isAuthError ? null : error,
     login: loginMutation.mutateAsync,

--- a/packages/api-client/src/client.test.ts
+++ b/packages/api-client/src/client.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Each test gets a fresh module to avoid one-shot setTokenStorage conflicts.
+async function importClient() {
+  const mod = await import('./client');
+  return mod;
+}
+
+describe('token storage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('setAuthToken without storage only updates in-memory state', async () => {
+    const { setAuthToken, getAuthToken } = await importClient();
+
+    setAuthToken('token-123');
+
+    expect(getAuthToken()).toBe('token-123');
+  });
+
+  it('setTokenStorage hydrates from storage.get()', async () => {
+    const { setTokenStorage, getAuthToken } = await importClient();
+    const storage = { get: () => 'persisted-token', set: vi.fn(), remove: vi.fn() };
+
+    setTokenStorage(storage);
+
+    expect(getAuthToken()).toBe('persisted-token');
+  });
+
+  it('setAuthToken delegates to storage.set() when storage is configured', async () => {
+    const { setTokenStorage, setAuthToken } = await importClient();
+    const storage = { get: () => null, set: vi.fn(), remove: vi.fn() };
+    setTokenStorage(storage);
+
+    setAuthToken('new-token');
+
+    expect(storage.set).toHaveBeenCalledWith('new-token');
+  });
+
+  it('setAuthToken(null) calls storage.remove()', async () => {
+    const { setTokenStorage, setAuthToken } = await importClient();
+    const storage = { get: () => 'old-token', set: vi.fn(), remove: vi.fn() };
+    setTokenStorage(storage);
+
+    setAuthToken(null);
+
+    expect(storage.remove).toHaveBeenCalled();
+    expect(storage.set).not.toHaveBeenCalled();
+  });
+
+  it('setTokenStorage throws if called twice', async () => {
+    const { setTokenStorage } = await importClient();
+    const storage = { get: () => null, set: vi.fn(), remove: vi.fn() };
+
+    setTokenStorage(storage);
+
+    expect(() => setTokenStorage(storage)).toThrow('TokenStorage has already been configured');
+  });
+});

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -30,10 +30,40 @@ export function getApiBase(): string {
   return apiBase;
 }
 
+export type TokenStorage = {
+  readonly get: () => string | null;
+  readonly set: (token: string) => void;
+  readonly remove: () => void;
+};
+
+let tokenStorage: TokenStorage | null = null;
 let authToken: string | null = null;
+
+/**
+ * Register a persistence backend for auth tokens. Must be called before
+ * any {@link setAuthToken} calls that need to survive across page loads.
+ * Immediately reads the stored token into memory via `storage.get()`.
+ *
+ * Can only be called once — throws if a storage backend is already registered.
+ * The storage interface is synchronous by design (localStorage, Electron safeStorage, etc.).
+ */
+export function setTokenStorage(storage: TokenStorage): void {
+  if (tokenStorage !== null) {
+    throw new Error('TokenStorage has already been configured');
+  }
+  tokenStorage = storage;
+  authToken = storage.get();
+}
 
 export function setAuthToken(token: string | null): void {
   authToken = token;
+  if (tokenStorage) {
+    if (token) {
+      tokenStorage.set(token);
+    } else {
+      tokenStorage.remove();
+    }
+  }
 }
 
 export function getAuthToken(): string | null {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -9,10 +9,12 @@ export {
   multipartRequest,
   setAuthToken,
   getAuthToken,
+  setTokenStorage,
   setApiBase,
   getApiBase,
   authHeaders,
 } from './client';
+export type { TokenStorage } from './client';
 
 // Re-export API wrappers
 export * from './api';


### PR DESCRIPTION
## Summary
- Extract token persistence from `useAuth`'s hardcoded `localStorage` calls into a `TokenStorage` interface on the shared `@enzyme/api-client` package, enabling platforms like Electron to provide their own storage backend
- `setTokenStorage` is one-shot (throws on double-call) and synchronous by design; `setAuthToken` now delegates to the configured storage adapter automatically
- Add unit tests for the `setTokenStorage`/`setAuthToken` integration in `@enzyme/api-client`

## Test plan
- `make test` passes (all 52 api-client tests + 314 web tests)
- `make lint` and typecheck pass
- New `packages/api-client/src/client.test.ts` covers: in-memory-only token set, storage hydration on init, delegation to `storage.set()`/`storage.remove()`, and one-shot guard
- Existing `useAuth` and `RequireAuth` tests updated to use the new API instead of raw `localStorage`

Closes #199