### PR TITLE
Document push notification delivery and configuration

### DIFF
--- a/apps/website/src/docs/configuration.md
+++ b/apps/website/src/docs/configuration.md
@@ -175,7 +175,7 @@ Push notifications deliver alerts to mobile devices when users are offline. Noti
 | `push_notifications.relay_url`       | `ENZYME_PUSH_NOTIFICATIONS_RELAY_URL`       | `--push_notifications.relay_url`       | `https://push.enzyme.im` | URL of the push relay service. Must use HTTPS (except for localhost).                   |
 | `push_notifications.include_preview` | `ENZYME_PUSH_NOTIFICATIONS_INCLUDE_PREVIEW` | `--push_notifications.include_preview` | `true`                   | Include a short message preview in the push notification body. Set `false` for privacy. |
 
-The default relay (`push.enzyme.im`) is operated by Enzyme and works out of the box. The relay sees only metadata (sender name, channel name) — message content is fetched by the mobile app directly from your server. See [Notifications](/docs/notifications/#push-notifications) for details on the delivery pipeline and privacy model.
+The default relay (`push.enzyme.im`) is operated by Enzyme and works out of the box. By default, the relay receives metadata (sender name, channel name) and a short message preview. Set `include_preview` to `false` to send only metadata — the mobile app will fetch message content directly from your server. See [Notifications](/docs/notifications/#push-notifications) for details on the delivery pipeline and privacy model.
 
 ## Telemetry (OpenTelemetry)
 

--- a/apps/website/src/docs/notifications.md
+++ b/apps/website/src/docs/notifications.md
@@ -51,7 +51,7 @@ Push suppresses email: if a push notification is successfully dispatched to at l
 
 Push notifications deliver alerts to mobile devices when a user is offline. They are sent through a relay service (`push.enzyme.im`) that holds the FCM and APNs credentials for the published app.
 
-**Privacy:** The relay receives only metadata (sender name, channel name, notification type). Message content is not included by default. The mobile app fetches full message content directly from its own Enzyme server when the user taps the notification.
+**Privacy:** By default, the relay receives metadata (sender name, channel name) and a short message preview. Set `include_preview: false` in your [push configuration](/docs/configuration/#push-notifications) to omit the preview — the relay will then receive only metadata, and the mobile app will fetch message content directly from your server when the user taps the notification.
 
 Push notifications are enabled by the server administrator. See [Push Notifications configuration](/docs/configuration/#push-notifications) for setup. No client-side configuration is needed — the mobile app handles device token registration automatically.
 

--- a/apps/website/src/docs/self-hosting.md
+++ b/apps/website/src/docs/self-hosting.md
@@ -202,9 +202,7 @@ push_notifications:
   enabled: true
 ```
 
-The relay (`push.enzyme.im`) holds the FCM/APNs credentials for the published mobile app and dispatches notifications on behalf of your server. It receives only metadata (sender name, channel name) — message content is fetched by the mobile app directly from your server.
-
-See [Push Notifications configuration](/docs/configuration/#push-notifications) for all options.
+The relay (`push.enzyme.im`) holds the FCM/APNs credentials for the published mobile app and dispatches notifications on behalf of your server. By default, it receives metadata and a short message preview. To omit message previews, set `include_preview: false`. See [Push Notifications configuration](/docs/configuration/#push-notifications) for all options.
 
 ## Running as a systemd Service
 


### PR DESCRIPTION
## Summary

- Add delivery pipeline overview to notifications docs explaining the SSE → Push → Email priority chain
- Add push notifications section covering privacy model and device token lifecycle
- Add `push_notifications.*` config keys to the configuration reference with full example
- Add quick-enable section to the self-hosting guide

## Test plan

- Verify docs render correctly on the website
- Check all internal links resolve (`#push-notifications`, `#email`, etc.)