### PR TITLE
Add documentation for mobile client

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - **Real-time** — Instant updates powered by Server-Sent Events
 - **Dark mode** — Full dark mode support
 - **Desktop app** — Native Electron app for macOS, Windows, and Linux
+- **Mobile app** — Native iOS and Android app built with React Native
 - **Single binary** — Deploy a single binary with the web client embedded
 
 ## Why Enzyme?
@@ -63,6 +64,7 @@ Enzyme is configured via config file, environment variables, or CLI flags. See t
 | [Messages]       | Message formatting and features         |
 | [Server]         | Go backend architecture and development |
 | [Web]            | React frontend architecture             |
+| [Mobile]         | React Native mobile app                 |
 
 [Self-Hosting]: https://enzyme.im/docs/self-hosting/
 [Configuration]: https://enzyme.im/docs/configuration/
@@ -74,6 +76,7 @@ Enzyme is configured via config file, environment variables, or CLI flags. See t
 [Messages]: https://enzyme.im/docs/messages/
 [Server]: server/README.md
 [Web]: apps/web/README.md
+[Mobile]: apps/mobile/README.md
 
 ## Contributing
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,107 @@
+# @enzyme/mobile
+
+React Native mobile client for Enzyme, built with Expo.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm
+- [Expo CLI](https://docs.expo.dev/get-started/set-up-your-environment/) (`npx expo`)
+- iOS Simulator (macOS) or Android Emulator
+
+## Development
+
+From the monorepo root:
+
+```bash
+make dev MOBILE=1    # Starts API server, web client, and Expo dev server
+```
+
+Or run just the mobile dev server:
+
+```bash
+pnpm --filter @enzyme/mobile dev
+```
+
+Then press `i` for iOS Simulator, `a` for Android Emulator, or scan the QR code with Expo Go on a physical device.
+
+## Architecture
+
+- **Expo SDK 54** — Managed workflow with React Native 0.81
+- **React Navigation** — Type-safe stack navigation (AuthStack + MainStack)
+- **NativeWind** — Tailwind CSS for React Native styling
+- **TanStack Query** — Server state via shared hooks from `@enzyme/shared`
+- **Zustand** — Client state via shared stores from `@enzyme/shared`
+- **react-native-sse** — Server-Sent Events for real-time updates
+- **Expo SecureStore** — Secure token storage
+- **Expo Notifications** — Push notifications via FCM/APNs
+
+### Shared Code
+
+The mobile app shares logic with the web client through `@enzyme/shared`:
+
+- **Hooks**: All TanStack Query hooks (useMessages, useAuth, useChannels, etc.)
+- **Stores**: Zustand stores for presence and message editing
+- **SSE cache updaters**: Handlers that update React Query cache on real-time events
+- **Utilities**: Query keys, emoji support, markdown parsing, mention handling
+
+Mobile-specific code lives in `apps/mobile/src/` — navigation, screens, native components, and platform hooks (SSE lifecycle, push notifications, app state).
+
+## Project Structure
+
+```
+src/
+├── navigation/          # React Navigation stacks and types
+│   ├── RootNavigator.tsx    # Auth state routing
+│   ├── AuthStack.tsx        # Unauthenticated screens
+│   ├── MainStack.tsx        # Authenticated screens
+│   └── types.ts             # Navigation param types
+├── screens/             # Screen components (13 screens)
+├── components/          # UI components
+│   └── ui/                  # Base primitives (Avatar, BottomSheet, etc.)
+├── hooks/               # Mobile-specific hooks
+│   ├── useSSE.ts            # SSE event dispatch
+│   ├── useSSELifecycle.ts   # Connect/disconnect on app state
+│   └── usePushNotifications.ts
+└── lib/                 # Utilities and providers
+    ├── sse.ts               # SSEConnection class
+    ├── bootstrap.ts         # App initialization
+    └── WorkspaceProvider.tsx # Active workspace context
+```
+
+## Testing
+
+```bash
+pnpm --filter @enzyme/mobile test:run    # Unit tests (vitest)
+pnpm --filter @enzyme/mobile typecheck   # Type checking
+pnpm --filter @enzyme/mobile lint        # Linting
+```
+
+## EAS Build
+
+Builds are managed through [Expo Application Services](https://expo.dev/eas).
+
+| Profile       | Purpose                | Distribution |
+| ------------- | ---------------------- | ------------ |
+| `development` | Dev client (simulator) | Internal     |
+| `preview`     | Beta testing           | Internal     |
+| `production`  | App store release      | Store        |
+
+```bash
+# Install EAS CLI
+npm install -g eas-cli
+
+# Build for a specific profile
+eas build --profile preview --platform ios
+eas build --profile preview --platform android
+eas build --profile production --platform all
+```
+
+Production builds auto-increment the build number. Code signing for OTA updates uses the certificate in `certs/`.
+
+## Configuration
+
+- **`app.json`** — Expo config (app name, bundle ID, splash screen, plugins)
+- **`eas.json`** — EAS Build profiles and update channels
+- **`tailwind.config.ts`** — NativeWind/Tailwind theme
+- **`metro.config.js`** — Metro bundler config (monorepo symlinks, NativeWind)

--- a/apps/website/src/docs/mobile-app.md
+++ b/apps/website/src/docs/mobile-app.md
@@ -1,0 +1,70 @@
+---
+title: 'Mobile App'
+description: 'Install and use the Enzyme mobile app on iOS and Android'
+section: 'Getting Started'
+order: 3
+---
+
+# Mobile App
+
+Enzyme has a native mobile app for iOS and Android, built with React Native and Expo. It supports the same features as the web client: channels, threads, direct messages, reactions, file sharing, search, and real-time updates.
+
+## Installation
+
+The mobile app is available through the following channels:
+
+- **iOS** — [App Store](https://apps.apple.com/app/enzyme/id0000000000) (requires iOS 16+)
+- **Android** — [Google Play](https://play.google.com/store/apps/details?id=im.enzyme.mobile) (requires Android 10+)
+
+## Connecting to Your Server
+
+When you first open the app, you'll be asked for your server URL. Enter the public URL of your Enzyme instance (e.g., `https://chat.example.com`). The app stores this URL so you only need to enter it once.
+
+If your server uses the default port (443 with TLS), just enter the domain. If it uses a custom port, include it in the URL (e.g., `https://chat.example.com:8443`).
+
+## Supported Platforms
+
+| Platform | Minimum Version |
+| -------- | --------------- |
+| iOS      | 16.0            |
+| Android  | 10 (API 29)     |
+
+## Push Notifications
+
+Push notifications are delivered when you're away from the app. They work automatically when your server administrator has [push notifications enabled](/docs/configuration/#push-notifications).
+
+No setup is required on your end — the app registers your device automatically when you sign in. You'll be prompted to allow notifications on first launch.
+
+### Privacy
+
+Push notifications are routed through a relay service (`push.enzyme.im`) that dispatches to Apple (APNs) and Google (FCM) on behalf of your server. By default, the relay receives:
+
+- Sender name and channel name (metadata)
+- A short message preview
+
+Server administrators can set `include_preview: false` to omit the message preview. In that case, the relay receives only metadata, and the app fetches message content directly from your server when you tap the notification.
+
+The relay does not store messages or notification content. It forwards the push payload and discards it.
+
+## Self-Hosting Administrators
+
+To support the mobile app on your self-hosted instance:
+
+1. **Enable push notifications** in your server config:
+
+   ```yaml
+   push_notifications:
+     enabled: true
+   ```
+
+2. The default relay (`push.enzyme.im`) works out of the box with the published app. No FCM/APNs credentials are needed on your end.
+
+3. Optionally disable message previews for privacy:
+
+   ```yaml
+   push_notifications:
+     enabled: true
+     include_preview: false
+   ```
+
+See [Push Notifications configuration](/docs/configuration/#push-notifications) for all options and [Notifications](/docs/notifications/#push-notifications) for the full delivery pipeline.


### PR DESCRIPTION
## Summary
- Add `apps/mobile/README.md` with development setup, architecture overview, EAS build profiles, and testing instructions
- Add mobile app page to website docs (`mobile-app.md`) covering installation, push notification privacy model, and self-hosting configuration
- Update root README with mobile app in features list and documentation table

## Test plan
- Verify `apps/mobile/README.md` renders correctly on GitHub
- Verify `apps/website/src/docs/mobile-app.md` renders at `/docs/mobile-app/` on the website
- Verify root README mobile link points to `apps/mobile/README.md`

Closes #211