### PR TITLE
Adopt modern SQLite features

### DIFF
--- a/apps/website/src/docs/configuration.md
+++ b/apps/website/src/docs/configuration.md
@@ -76,14 +76,14 @@ Run `./enzyme --help` for all available flags.
 
 ## Database
 
-| Key                       | Env Var                          | CLI Flag          | Default            | Description                                                                                              |
-| ------------------------- | -------------------------------- | ----------------- | ------------------ | -------------------------------------------------------------------------------------------------------- |
-| `database.path`           | `ENZYME_DATABASE_PATH`           | `--database.path` | `./data/enzyme.db` | Path to the SQLite database file. The directory must exist.                                              |
-| `database.max_open_conns`      | `ENZYME_DATABASE_MAX_OPEN_CONNS`      |                   | `10`          | Max open database connections. Allows concurrent reads with WAL mode. Minimum: 1.                        |
-| `database.busy_timeout`        | `ENZYME_DATABASE_BUSY_TIMEOUT`        |                   | `5000`        | Milliseconds to wait when the database is locked before returning SQLITE_BUSY. Minimum: 0.               |
-| `database.cache_size`          | `ENZYME_DATABASE_CACHE_SIZE`          |                   | `-8000`       | SQLite page cache size. Negative values = KB (e.g., `-8000` = ~8 MB). Positive values = number of pages. |
-| `database.mmap_size`           | `ENZYME_DATABASE_MMAP_SIZE`           |                   | `268435456`   | Memory-mapped I/O size in bytes. `0` disables mmap. Default is 256 MB.                                   |
-| `database.journal_size_limit`  | `ENZYME_DATABASE_JOURNAL_SIZE_LIMIT`  |                   | `67108864`    | Max WAL file size in bytes. Caps WAL growth during heavy writes. Default is 64 MB.                        |
+| Key                           | Env Var                              | CLI Flag          | Default            | Description                                                                                              |
+| ----------------------------- | ------------------------------------ | ----------------- | ------------------ | -------------------------------------------------------------------------------------------------------- |
+| `database.path`               | `ENZYME_DATABASE_PATH`               | `--database.path` | `./data/enzyme.db` | Path to the SQLite database file. The directory must exist.                                              |
+| `database.max_open_conns`     | `ENZYME_DATABASE_MAX_OPEN_CONNS`     |                   | `10`               | Max open database connections. Allows concurrent reads with WAL mode. Minimum: 1.                        |
+| `database.busy_timeout`       | `ENZYME_DATABASE_BUSY_TIMEOUT`       |                   | `5000`             | Milliseconds to wait when the database is locked before returning SQLITE_BUSY. Minimum: 0.               |
+| `database.cache_size`         | `ENZYME_DATABASE_CACHE_SIZE`         |                   | `-8000`            | SQLite page cache size. Negative values = KB (e.g., `-8000` = ~8 MB). Positive values = number of pages. |
+| `database.mmap_size`          | `ENZYME_DATABASE_MMAP_SIZE`          |                   | `268435456`        | Memory-mapped I/O size in bytes. `0` disables mmap. Default is 256 MB.                                   |
+| `database.journal_size_limit` | `ENZYME_DATABASE_JOURNAL_SIZE_LIMIT` |                   | `67108864`         | Max WAL file size in bytes. Caps WAL growth during heavy writes. Default is 64 MB.                       |
 
 Enzyme uses SQLite in WAL mode. No external database server is needed. See [Scaling Guide](/docs/scaling/) for tuning guidance.
 

--- a/apps/website/src/docs/configuration.md
+++ b/apps/website/src/docs/configuration.md
@@ -79,10 +79,11 @@ Run `./enzyme --help` for all available flags.
 | Key                       | Env Var                          | CLI Flag          | Default            | Description                                                                                              |
 | ------------------------- | -------------------------------- | ----------------- | ------------------ | -------------------------------------------------------------------------------------------------------- |
 | `database.path`           | `ENZYME_DATABASE_PATH`           | `--database.path` | `./data/enzyme.db` | Path to the SQLite database file. The directory must exist.                                              |
-| `database.max_open_conns` | `ENZYME_DATABASE_MAX_OPEN_CONNS` |                   | `2`                | Max open database connections. Allows concurrent reads with WAL mode. Minimum: 1.                        |
-| `database.busy_timeout`   | `ENZYME_DATABASE_BUSY_TIMEOUT`   |                   | `5000`             | Milliseconds to wait when the database is locked before returning SQLITE_BUSY. Minimum: 0.               |
-| `database.cache_size`     | `ENZYME_DATABASE_CACHE_SIZE`     |                   | `-2000`            | SQLite page cache size. Negative values = KB (e.g., `-2000` = ~2 MB). Positive values = number of pages. |
-| `database.mmap_size`      | `ENZYME_DATABASE_MMAP_SIZE`      |                   | `0`                | Memory-mapped I/O size in bytes. `0` disables mmap. Set higher for large databases on capable hardware.  |
+| `database.max_open_conns`      | `ENZYME_DATABASE_MAX_OPEN_CONNS`      |                   | `10`          | Max open database connections. Allows concurrent reads with WAL mode. Minimum: 1.                        |
+| `database.busy_timeout`        | `ENZYME_DATABASE_BUSY_TIMEOUT`        |                   | `5000`        | Milliseconds to wait when the database is locked before returning SQLITE_BUSY. Minimum: 0.               |
+| `database.cache_size`          | `ENZYME_DATABASE_CACHE_SIZE`          |                   | `-8000`       | SQLite page cache size. Negative values = KB (e.g., `-8000` = ~8 MB). Positive values = number of pages. |
+| `database.mmap_size`           | `ENZYME_DATABASE_MMAP_SIZE`           |                   | `268435456`   | Memory-mapped I/O size in bytes. `0` disables mmap. Default is 256 MB.                                   |
+| `database.journal_size_limit`  | `ENZYME_DATABASE_JOURNAL_SIZE_LIMIT`  |                   | `67108864`    | Max WAL file size in bytes. Caps WAL growth during heavy writes. Default is 64 MB.                        |
 
 Enzyme uses SQLite in WAL mode. No external database server is needed. See [Scaling Guide](/docs/scaling/) for tuning guidance.
 
@@ -236,10 +237,11 @@ server:
 
 database:
   path: '/var/lib/enzyme/enzyme.db'
-  max_open_conns: 2
+  max_open_conns: 10
   busy_timeout: 5000
-  cache_size: -2000
-  mmap_size: 0
+  cache_size: -8000
+  mmap_size: 268435456
+  journal_size_limit: 67108864
 
 auth:
   session_duration: '720h'

--- a/apps/website/src/docs/scaling.md
+++ b/apps/website/src/docs/scaling.md
@@ -17,13 +17,13 @@ For a full list of configurable options, see [Configuration Reference](/docs/con
 
 SQLite handles all storage in Enzyme. These pragmas are set per-connection via DSN parameters, so every connection in the pool gets them.
 
-| Setting              | Config Key                      | Default       | What It Does                                                                                           |
-| -------------------- | ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------ |
-| `max_open_conns`     | `database.max_open_conns`       | `10`          | Number of connections in the pool. With WAL mode, readers don't block writers, so >1 is safe.          |
-| `busy_timeout`       | `database.busy_timeout`         | `5000`        | Milliseconds to retry when the database is locked, before returning `SQLITE_BUSY`.                     |
-| `cache_size`         | `database.cache_size`           | `-8000`       | Page cache size **per connection**. Negative = KB (`-8000` = ~8 MB). Larger cache = fewer disk reads.  |
-| `mmap_size`          | `database.mmap_size`            | `268435456`   | Memory-mapped I/O in bytes. `0` = disabled. Default is 256 MB. Enables the OS to page database data directly into memory. |
-| `journal_size_limit` | `database.journal_size_limit`   | `67108864`    | Max WAL file size in bytes. Default is 64 MB. Caps WAL growth during heavy writes.                     |
+| Setting              | Config Key                    | Default     | What It Does                                                                                                              |
+| -------------------- | ----------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `max_open_conns`     | `database.max_open_conns`     | `10`        | Number of connections in the pool. With WAL mode, readers don't block writers, so >1 is safe.                             |
+| `busy_timeout`       | `database.busy_timeout`       | `5000`      | Milliseconds to retry when the database is locked, before returning `SQLITE_BUSY`.                                        |
+| `cache_size`         | `database.cache_size`         | `-8000`     | Page cache size **per connection**. Negative = KB (`-8000` = ~8 MB). Larger cache = fewer disk reads.                     |
+| `mmap_size`          | `database.mmap_size`          | `268435456` | Memory-mapped I/O in bytes. `0` = disabled. Default is 256 MB. Enables the OS to page database data directly into memory. |
+| `journal_size_limit` | `database.journal_size_limit` | `67108864`  | Max WAL file size in bytes. Default is 64 MB. Caps WAL growth during heavy writes.                                        |
 
 ### When to Adjust
 

--- a/apps/website/src/docs/scaling.md
+++ b/apps/website/src/docs/scaling.md
@@ -17,21 +17,22 @@ For a full list of configurable options, see [Configuration Reference](/docs/con
 
 SQLite handles all storage in Enzyme. These pragmas are set per-connection via DSN parameters, so every connection in the pool gets them.
 
-| Setting          | Config Key                | Default | What It Does                                                                                           |
-| ---------------- | ------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `max_open_conns` | `database.max_open_conns` | `2`     | Number of connections in the pool. With WAL mode, readers don't block writers, so >1 is safe.          |
-| `busy_timeout`   | `database.busy_timeout`   | `5000`  | Milliseconds to retry when the database is locked, before returning `SQLITE_BUSY`.                     |
-| `cache_size`     | `database.cache_size`     | `-2000` | Page cache size **per connection**. Negative = KB (`-2000` = ~2 MB). Larger cache = fewer disk reads.  |
-| `mmap_size`      | `database.mmap_size`      | `0`     | Memory-mapped I/O in bytes. `0` = disabled. Enables the OS to page database data directly into memory. |
+| Setting              | Config Key                      | Default       | What It Does                                                                                           |
+| -------------------- | ------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------ |
+| `max_open_conns`     | `database.max_open_conns`       | `10`          | Number of connections in the pool. With WAL mode, readers don't block writers, so >1 is safe.          |
+| `busy_timeout`       | `database.busy_timeout`         | `5000`        | Milliseconds to retry when the database is locked, before returning `SQLITE_BUSY`.                     |
+| `cache_size`         | `database.cache_size`           | `-8000`       | Page cache size **per connection**. Negative = KB (`-8000` = ~8 MB). Larger cache = fewer disk reads.  |
+| `mmap_size`          | `database.mmap_size`            | `268435456`   | Memory-mapped I/O in bytes. `0` = disabled. Default is 256 MB. Enables the OS to page database data directly into memory. |
+| `journal_size_limit` | `database.journal_size_limit`   | `67108864`    | Max WAL file size in bytes. Default is 64 MB. Caps WAL growth during heavy writes.                     |
 
 ### When to Adjust
 
-- **More concurrent users**: Increase `max_open_conns` (4-8 is reasonable for most workloads). Each read query can run on its own connection without blocking writes. With the default of `2`, a single slow query (e.g., notification aggregation across many channels) can hold one connection while every other handler — auth validation, message sends, SSE event persistence — queues behind the remaining one.
+- **More concurrent users**: Increase `max_open_conns` beyond the default of 10 if you consistently see connection pool exhaustion under high load.
 - **Write contention errors**: Increase `busy_timeout`. If you see `SQLITE_BUSY` in logs, the default 5 seconds isn't enough for your write volume.
-- **Slow queries on large databases**: Increase `cache_size` (e.g., `-64000` for ~64 MB) and enable `mmap_size` (e.g., `268435456` for 256 MB). This keeps hot pages in memory.
-- **Small VPS with limited RAM**: Keep defaults. The ~2 MB per-connection cache is intentionally conservative.
+- **Slow queries on large databases**: Increase `cache_size` (e.g., `-64000` for ~64 MB) and `mmap_size` (e.g., `1073741824` for 1 GB). This keeps hot pages in memory.
+- **Small VPS with limited RAM**: Lower `cache_size` (e.g., `-2000` for ~2 MB) and `mmap_size` (e.g., `0` to disable). The defaults are tuned for moderate workloads.
 
-> **Note:** `cache_size` is per-connection. Total cache memory is roughly `cache_size × max_open_conns`. With the defaults (`-2000` and `2`), that's ~4 MB total.
+> **Note:** `cache_size` is per-connection. Total cache memory is roughly `cache_size × max_open_conns`. With the defaults (`-8000` and `10`), that's ~80 MB total.
 
 ---
 
@@ -267,6 +268,6 @@ Key metrics to watch when scaling:
 - **SSE connection count**: Monitor the number of active SSE clients. Each consumes memory proportional to `client_buffer_size`.
 - **Memory usage**: (`cache_size` x `max_open_conns`) + `mmap_size` + (SSE clients x buffer size x avg event size) gives a rough memory floor.
 - **File descriptors**: `ls /proc/$(pidof enzyme)/fd | wc -l` shows current usage. Compare to `LimitNOFILE`.
-- **Response latency**: If P99 response times degrade, check `max_open_conns` first. Expensive read queries (like notification aggregation) can hold connections for hundreds of milliseconds, starving other handlers. Increasing the pool size (e.g., to 4-8) gives handlers their own connections. If latency persists after that, the database may benefit from a larger cache or mmap. Use `EXPLAIN QUERY PLAN` on slow queries to verify they're using indexes.
+- **Response latency**: If P99 response times degrade, check whether `max_open_conns` is sufficient. Expensive read queries (like notification aggregation) can hold connections for hundreds of milliseconds, starving other handlers. If latency persists, the database may benefit from a larger cache or mmap. Use `EXPLAIN QUERY PLAN` on slow queries to verify they're using indexes.
 - **TCP memory**: During SSE broadcast bursts, check `cat /proc/net/sockstat | grep TCP` — if the `mem` value approaches the kernel's `tcp_mem` pressure threshold, connections will be dropped. See [TCP Memory](#tcp-memory) above.
 - **Trace export backpressure**: If the OTLP exporter queue fills up, you'll see dropped spans in logs. Lower `sample_rate` or scale your collector.

--- a/server/cmd/enzyme/main.go
+++ b/server/cmd/enzyme/main.go
@@ -101,10 +101,11 @@ func runSeed(args []string) {
 
 	// Open database and run migrations (no full app startup)
 	db, err := database.Open(cfg.Database.Path, database.Options{
-		MaxOpenConns: cfg.Database.MaxOpenConns,
-		BusyTimeout:  cfg.Database.BusyTimeout,
-		CacheSize:    cfg.Database.CacheSize,
-		MmapSize:     cfg.Database.MmapSize,
+		MaxOpenConns:     cfg.Database.MaxOpenConns,
+		BusyTimeout:      cfg.Database.BusyTimeout,
+		CacheSize:        cfg.Database.CacheSize,
+		MmapSize:         cfg.Database.MmapSize,
+		JournalSizeLimit: cfg.Database.JournalSizeLimit,
 	})
 	if err != nil {
 		slog.Error("error opening database", "error", err)

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -65,10 +65,11 @@ type App struct {
 func New(cfg *config.Config) (*App, error) {
 	// Open database
 	db, err := database.Open(cfg.Database.Path, database.Options{
-		MaxOpenConns: cfg.Database.MaxOpenConns,
-		BusyTimeout:  cfg.Database.BusyTimeout,
-		CacheSize:    cfg.Database.CacheSize,
-		MmapSize:     cfg.Database.MmapSize,
+		MaxOpenConns:     cfg.Database.MaxOpenConns,
+		BusyTimeout:      cfg.Database.BusyTimeout,
+		CacheSize:        cfg.Database.CacheSize,
+		MmapSize:         cfg.Database.MmapSize,
+		JournalSizeLimit: cfg.Database.JournalSizeLimit,
 	})
 	if err != nil {
 		return nil, err

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -45,11 +45,12 @@ type AutoTLSConfig struct {
 }
 
 type DatabaseConfig struct {
-	Path         string `koanf:"path"`
-	MaxOpenConns int    `koanf:"max_open_conns"`
-	BusyTimeout  int    `koanf:"busy_timeout"`
-	CacheSize    int    `koanf:"cache_size"`
-	MmapSize     int64  `koanf:"mmap_size"`
+	Path              string `koanf:"path"`
+	MaxOpenConns      int    `koanf:"max_open_conns"`
+	BusyTimeout       int    `koanf:"busy_timeout"`
+	CacheSize         int    `koanf:"cache_size"`
+	MmapSize          int64  `koanf:"mmap_size"`
+	JournalSizeLimit  int64  `koanf:"journal_size_limit"`
 }
 
 type AuthConfig struct {
@@ -153,11 +154,12 @@ func Defaults() *Config {
 			IdleTimeout:  120 * time.Second,
 		},
 		Database: DatabaseConfig{
-			Path:         "./data/enzyme.db",
-			MaxOpenConns: 10,
-			BusyTimeout:  5000,
-			CacheSize:    -8000,
-			MmapSize:     268435456, // 256MB
+			Path:             "./data/enzyme.db",
+			MaxOpenConns:     10,
+			BusyTimeout:      5000,
+			CacheSize:        -8000,
+			MmapSize:         268435456, // 256MB
+			JournalSizeLimit: 67108864,  // 64MB
 		},
 		Auth: AuthConfig{
 			SessionDuration: 720 * time.Hour, // 30 days

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -156,7 +156,8 @@ func Defaults() *Config {
 			Path:         "./data/enzyme.db",
 			MaxOpenConns: 10,
 			BusyTimeout:  5000,
-			CacheSize:    -2000,
+			CacheSize:    -8000,
+			MmapSize:     268435456, // 256MB
 		},
 		Auth: AuthConfig{
 			SessionDuration: 720 * time.Hour, // 30 days

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -45,12 +45,12 @@ type AutoTLSConfig struct {
 }
 
 type DatabaseConfig struct {
-	Path              string `koanf:"path"`
-	MaxOpenConns      int    `koanf:"max_open_conns"`
-	BusyTimeout       int    `koanf:"busy_timeout"`
-	CacheSize         int    `koanf:"cache_size"`
-	MmapSize          int64  `koanf:"mmap_size"`
-	JournalSizeLimit  int64  `koanf:"journal_size_limit"`
+	Path             string `koanf:"path"`
+	MaxOpenConns     int    `koanf:"max_open_conns"`
+	BusyTimeout      int    `koanf:"busy_timeout"`
+	CacheSize        int    `koanf:"cache_size"`
+	MmapSize         int64  `koanf:"mmap_size"`
+	JournalSizeLimit int64  `koanf:"journal_size_limit"`
 }
 
 type AuthConfig struct {

--- a/server/internal/database/database.go
+++ b/server/internal/database/database.go
@@ -16,10 +16,11 @@ type DB struct {
 
 // Options controls SQLite connection pool and pragma settings.
 type Options struct {
-	MaxOpenConns int   // max open connections (default: 10)
-	BusyTimeout  int   // milliseconds to wait on lock (default: 5000)
-	CacheSize    int   // negative = KB, positive = pages (default: -2000)
-	MmapSize     int64 // bytes, 0 = disabled (default: 0)
+	MaxOpenConns     int   // max open connections (default: 10)
+	BusyTimeout      int   // milliseconds to wait on lock (default: 5000)
+	CacheSize        int   // negative = KB, positive = pages (default: -2000)
+	MmapSize         int64 // bytes, 0 = disabled (default: 0)
+	JournalSizeLimit int64 // bytes, caps WAL file size (default: 67108864 = 64MB)
 }
 
 func Open(path string, opts Options) (*DB, error) {
@@ -39,10 +40,10 @@ func Open(path string, opts Options) (*DB, error) {
 	// SQLite returns SQLITE_BUSY instantly to avoid deadlocks.
 	// temp_store=2 uses memory-backed temp tables instead of disk, avoiding
 	// temp file I/O for ORDER BY, GROUP BY, and window functions.
-	// journal_size_limit caps the WAL file at 64MB, preventing unbounded
-	// growth during long-running operations or heavy write bursts.
-	dsn := fmt.Sprintf("%s?_txlock=immediate&_pragma=journal_mode%%28WAL%%29&_pragma=busy_timeout%%28%d%%29&_pragma=foreign_keys%%28ON%%29&_pragma=synchronous%%28NORMAL%%29&_pragma=cache_size%%28%d%%29&_pragma=mmap_size%%28%d%%29&_pragma=temp_store%%282%%29&_pragma=journal_size_limit%%2867108864%%29",
-		path, opts.BusyTimeout, opts.CacheSize, opts.MmapSize)
+	// journal_size_limit caps the WAL file, preventing unbounded growth
+	// during long-running operations or heavy write bursts.
+	dsn := fmt.Sprintf("%s?_txlock=immediate&_pragma=journal_mode%%28WAL%%29&_pragma=busy_timeout%%28%d%%29&_pragma=foreign_keys%%28ON%%29&_pragma=synchronous%%28NORMAL%%29&_pragma=cache_size%%28%d%%29&_pragma=mmap_size%%28%d%%29&_pragma=temp_store%%282%%29&_pragma=journal_size_limit%%28%d%%29",
+		path, opts.BusyTimeout, opts.CacheSize, opts.MmapSize, opts.JournalSizeLimit)
 
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/server/internal/database/database.go
+++ b/server/internal/database/database.go
@@ -39,7 +39,9 @@ func Open(path string, opts Options) (*DB, error) {
 	// SQLite returns SQLITE_BUSY instantly to avoid deadlocks.
 	// temp_store=2 uses memory-backed temp tables instead of disk, avoiding
 	// temp file I/O for ORDER BY, GROUP BY, and window functions.
-	dsn := fmt.Sprintf("%s?_txlock=immediate&_pragma=journal_mode%%28WAL%%29&_pragma=busy_timeout%%28%d%%29&_pragma=foreign_keys%%28ON%%29&_pragma=synchronous%%28NORMAL%%29&_pragma=cache_size%%28%d%%29&_pragma=mmap_size%%28%d%%29&_pragma=temp_store%%282%%29",
+	// journal_size_limit caps the WAL file at 64MB, preventing unbounded
+	// growth during long-running operations or heavy write bursts.
+	dsn := fmt.Sprintf("%s?_txlock=immediate&_pragma=journal_mode%%28WAL%%29&_pragma=busy_timeout%%28%d%%29&_pragma=foreign_keys%%28ON%%29&_pragma=synchronous%%28NORMAL%%29&_pragma=cache_size%%28%d%%29&_pragma=mmap_size%%28%d%%29&_pragma=temp_store%%282%%29&_pragma=journal_size_limit%%2867108864%%29",
 		path, opts.BusyTimeout, opts.CacheSize, opts.MmapSize)
 
 	db, err := sql.Open("sqlite", dsn)

--- a/server/internal/notification/preferences.go
+++ b/server/internal/notification/preferences.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -60,8 +61,12 @@ func (r *PreferencesRepository) Get(ctx context.Context, userID, channelID strin
 		return nil, err
 	}
 
-	pref.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
-	pref.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+	if pref.CreatedAt, err = time.Parse(time.RFC3339, createdAt); err != nil {
+		return nil, fmt.Errorf("parsing created_at: %w", err)
+	}
+	if pref.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt); err != nil {
+		return nil, fmt.Errorf("parsing updated_at: %w", err)
+	}
 
 	return &pref, nil
 }
@@ -112,8 +117,12 @@ func (r *PreferencesRepository) Upsert(ctx context.Context, pref *NotificationPr
 		return err
 	}
 
-	pref.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
-	pref.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+	if pref.CreatedAt, err = time.Parse(time.RFC3339, createdAt); err != nil {
+		return fmt.Errorf("parsing created_at: %w", err)
+	}
+	if pref.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt); err != nil {
+		return fmt.Errorf("parsing updated_at: %w", err)
+	}
 
 	return nil
 }
@@ -149,8 +158,12 @@ func (r *PreferencesRepository) ListForUser(ctx context.Context, userID string) 
 			return nil, err
 		}
 
-		pref.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
-		pref.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+		if pref.CreatedAt, err = time.Parse(time.RFC3339, createdAt); err != nil {
+			return nil, fmt.Errorf("parsing created_at: %w", err)
+		}
+		if pref.UpdatedAt, err = time.Parse(time.RFC3339, updatedAt); err != nil {
+			return nil, fmt.Errorf("parsing updated_at: %w", err)
+		}
 		prefs = append(prefs, pref)
 	}
 

--- a/server/internal/notification/preferences.go
+++ b/server/internal/notification/preferences.go
@@ -92,36 +92,30 @@ func (r *PreferencesRepository) GetOrDefault(ctx context.Context, userID, channe
 
 // Upsert creates or updates notification preferences
 func (r *PreferencesRepository) Upsert(ctx context.Context, pref *NotificationPreference) error {
-	now := time.Now().UTC()
+	now := time.Now().UTC().Format(time.RFC3339)
+	id := ulid.Make().String()
 
-	// Try to update first
-	result, err := r.db.ExecContext(ctx, `
-		UPDATE notification_preferences
-		SET notify_level = ?, email_enabled = ?, updated_at = ?
-		WHERE user_id = ? AND channel_id = ?
-	`, pref.NotifyLevel, pref.EmailEnabled, now.Format(time.RFC3339), pref.UserID, pref.ChannelID)
+	var createdAt, updatedAt string
+	err := r.db.QueryRowContext(ctx, `
+		INSERT INTO notification_preferences (id, user_id, channel_id, notify_level, email_enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(user_id, channel_id) DO UPDATE SET
+			notify_level = excluded.notify_level,
+			email_enabled = excluded.email_enabled,
+			updated_at = excluded.updated_at
+		RETURNING id, user_id, channel_id, notify_level, email_enabled, created_at, updated_at
+	`, id, pref.UserID, pref.ChannelID, pref.NotifyLevel, pref.EmailEnabled, now, now).Scan(
+		&pref.ID, &pref.UserID, &pref.ChannelID, &pref.NotifyLevel, &pref.EmailEnabled,
+		&createdAt, &updatedAt,
+	)
 	if err != nil {
 		return err
 	}
 
-	rows, _ := result.RowsAffected()
-	if rows > 0 {
-		pref.UpdatedAt = now
-		return nil
-	}
+	pref.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	pref.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
 
-	// Insert new preference
-	pref.ID = ulid.Make().String()
-	pref.CreatedAt = now
-	pref.UpdatedAt = now
-
-	_, err = r.db.ExecContext(ctx, `
-		INSERT INTO notification_preferences (id, user_id, channel_id, notify_level, email_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`, pref.ID, pref.UserID, pref.ChannelID, pref.NotifyLevel, pref.EmailEnabled,
-		now.Format(time.RFC3339), now.Format(time.RFC3339))
-
-	return err
+	return nil
 }
 
 // Delete removes notification preferences

--- a/server/internal/notification/preferences_test.go
+++ b/server/internal/notification/preferences_test.go
@@ -1,0 +1,139 @@
+package notification
+
+import (
+	"context"
+	"testing"
+
+	"github.com/enzyme/server/internal/testutil"
+)
+
+func TestPreferencesRepository_Upsert_Insert(t *testing.T) {
+	db := testutil.TestDB(t)
+	repo := NewPreferencesRepository(db)
+	ctx := context.Background()
+
+	user := testutil.CreateTestUser(t, db, "user@example.com", "User")
+	ws := testutil.CreateTestWorkspace(t, db, user.ID, "Test WS")
+	ch := testutil.CreateTestChannel(t, db, ws.ID, user.ID, "general", "public")
+
+	pref := &NotificationPreference{
+		UserID:       user.ID,
+		ChannelID:    ch.ID,
+		NotifyLevel:  NotifyAll,
+		EmailEnabled: true,
+	}
+
+	err := repo.Upsert(ctx, pref)
+	if err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	if pref.ID == "" {
+		t.Error("expected non-empty ID after insert")
+	}
+	if pref.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+	if pref.UpdatedAt.IsZero() {
+		t.Error("expected non-zero UpdatedAt")
+	}
+
+	// Verify via Get
+	got, err := repo.Get(ctx, user.ID, ch.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.NotifyLevel != NotifyAll {
+		t.Errorf("NotifyLevel = %q, want %q", got.NotifyLevel, NotifyAll)
+	}
+}
+
+func TestPreferencesRepository_Upsert_Update(t *testing.T) {
+	db := testutil.TestDB(t)
+	repo := NewPreferencesRepository(db)
+	ctx := context.Background()
+
+	user := testutil.CreateTestUser(t, db, "user@example.com", "User")
+	ws := testutil.CreateTestWorkspace(t, db, user.ID, "Test WS")
+	ch := testutil.CreateTestChannel(t, db, ws.ID, user.ID, "general", "public")
+
+	// Insert
+	pref := &NotificationPreference{
+		UserID:       user.ID,
+		ChannelID:    ch.ID,
+		NotifyLevel:  NotifyAll,
+		EmailEnabled: true,
+	}
+	if err := repo.Upsert(ctx, pref); err != nil {
+		t.Fatalf("initial Upsert() error = %v", err)
+	}
+	originalID := pref.ID
+	originalCreatedAt := pref.CreatedAt
+
+	// Update via second upsert
+	pref2 := &NotificationPreference{
+		UserID:       user.ID,
+		ChannelID:    ch.ID,
+		NotifyLevel:  NotifyMentions,
+		EmailEnabled: false,
+	}
+	if err := repo.Upsert(ctx, pref2); err != nil {
+		t.Fatalf("update Upsert() error = %v", err)
+	}
+
+	// ID should be preserved (ON CONFLICT updates existing row)
+	if pref2.ID != originalID {
+		t.Errorf("ID changed: %q != %q", pref2.ID, originalID)
+	}
+	// CreatedAt should be preserved
+	if !pref2.CreatedAt.Equal(originalCreatedAt) {
+		t.Errorf("CreatedAt changed: %v != %v", pref2.CreatedAt, originalCreatedAt)
+	}
+
+	// Verify the update took effect
+	got, err := repo.Get(ctx, user.ID, ch.ID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.NotifyLevel != NotifyMentions {
+		t.Errorf("NotifyLevel = %q, want %q", got.NotifyLevel, NotifyMentions)
+	}
+	if got.EmailEnabled != false {
+		t.Error("expected EmailEnabled = false")
+	}
+}
+
+func TestPreferencesRepository_Upsert_PopulatesAllFields(t *testing.T) {
+	db := testutil.TestDB(t)
+	repo := NewPreferencesRepository(db)
+	ctx := context.Background()
+
+	user := testutil.CreateTestUser(t, db, "user@example.com", "User")
+	ws := testutil.CreateTestWorkspace(t, db, user.ID, "Test WS")
+	ch := testutil.CreateTestChannel(t, db, ws.ID, user.ID, "general", "public")
+
+	pref := &NotificationPreference{
+		UserID:       user.ID,
+		ChannelID:    ch.ID,
+		NotifyLevel:  NotifyNone,
+		EmailEnabled: false,
+	}
+
+	if err := repo.Upsert(ctx, pref); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	// All fields should be populated from RETURNING
+	if pref.ID == "" {
+		t.Error("expected ID to be populated")
+	}
+	if pref.UserID != user.ID {
+		t.Errorf("UserID = %q, want %q", pref.UserID, user.ID)
+	}
+	if pref.ChannelID != ch.ID {
+		t.Errorf("ChannelID = %q, want %q", pref.ChannelID, ch.ID)
+	}
+	if pref.NotifyLevel != NotifyNone {
+		t.Errorf("NotifyLevel = %q, want %q", pref.NotifyLevel, NotifyNone)
+	}
+}

--- a/server/internal/thread/repository.go
+++ b/server/internal/thread/repository.go
@@ -26,11 +26,20 @@ func (r *Repository) GetSubscription(ctx context.Context, threadParentID, userID
 		WHERE thread_parent_id = ? AND user_id = ?
 	`
 
+	sub, err := r.scanSubscription(r.db.QueryRowContext(ctx, query, threadParentID, userID))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	return sub, err
+}
+
+// scanSubscription scans a single row into a Subscription.
+func (r *Repository) scanSubscription(row *sql.Row) (*Subscription, error) {
 	var sub Subscription
 	var lastReadReplyID sql.NullString
 	var createdAt, updatedAt string
 
-	err := r.db.QueryRowContext(ctx, query, threadParentID, userID).Scan(
+	err := row.Scan(
 		&sub.ID,
 		&sub.ThreadParentID,
 		&sub.UserID,
@@ -39,9 +48,6 @@ func (r *Repository) GetSubscription(ctx context.Context, threadParentID, userID
 		&createdAt,
 		&updatedAt,
 	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -85,22 +91,16 @@ func (r *Repository) Subscribe(ctx context.Context, threadParentID, userID strin
 	now := time.Now().UTC().Format(time.RFC3339)
 	id := ulid.Make().String()
 
-	// Use INSERT OR REPLACE to handle both new and existing subscriptions
 	query := `
 		INSERT INTO thread_subscriptions (id, thread_parent_id, user_id, status, created_at, updated_at)
 		VALUES (?, ?, ?, 'subscribed', ?, ?)
 		ON CONFLICT(thread_parent_id, user_id) DO UPDATE SET
 			status = 'subscribed',
 			updated_at = excluded.updated_at
+		RETURNING id, thread_parent_id, user_id, status, last_read_reply_id, created_at, updated_at
 	`
 
-	_, err := r.db.ExecContext(ctx, query, id, threadParentID, userID, now, now)
-	if err != nil {
-		return nil, err
-	}
-
-	// Fetch the updated/created subscription
-	return r.GetSubscription(ctx, threadParentID, userID)
+	return r.scanSubscription(r.db.QueryRowContext(ctx, query, id, threadParentID, userID, now, now))
 }
 
 // Unsubscribe creates or updates a subscription to "unsubscribed" status
@@ -108,22 +108,16 @@ func (r *Repository) Unsubscribe(ctx context.Context, threadParentID, userID str
 	now := time.Now().UTC().Format(time.RFC3339)
 	id := ulid.Make().String()
 
-	// Use INSERT OR REPLACE to handle both new and existing subscriptions
 	query := `
 		INSERT INTO thread_subscriptions (id, thread_parent_id, user_id, status, created_at, updated_at)
 		VALUES (?, ?, ?, 'unsubscribed', ?, ?)
 		ON CONFLICT(thread_parent_id, user_id) DO UPDATE SET
 			status = 'unsubscribed',
 			updated_at = excluded.updated_at
+		RETURNING id, thread_parent_id, user_id, status, last_read_reply_id, created_at, updated_at
 	`
 
-	_, err := r.db.ExecContext(ctx, query, id, threadParentID, userID, now, now)
-	if err != nil {
-		return nil, err
-	}
-
-	// Fetch the updated/created subscription
-	return r.GetSubscription(ctx, threadParentID, userID)
+	return r.scanSubscription(r.db.QueryRowContext(ctx, query, id, threadParentID, userID, now, now))
 }
 
 // AutoSubscribe subscribes a user to a thread ONLY if they have no existing subscription row.

--- a/server/internal/thread/repository_test.go
+++ b/server/internal/thread/repository_test.go
@@ -1,0 +1,112 @@
+package thread
+
+import (
+	"context"
+	"testing"
+
+	"github.com/enzyme/server/internal/testutil"
+)
+
+func TestRepository_Subscribe_NewSubscription(t *testing.T) {
+	db := testutil.TestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	user := testutil.CreateTestUser(t, db, "user@example.com", "User")
+	ws := testutil.CreateTestWorkspace(t, db, user.ID, "Test WS")
+	ch := testutil.CreateTestChannel(t, db, ws.ID, user.ID, "general", "public")
+	msg := testutil.CreateTestMessage(t, db, ch.ID, user.ID, "thread parent")
+
+	sub, err := repo.Subscribe(ctx, msg.ID, user.ID)
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	if sub.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if sub.ThreadParentID != msg.ID {
+		t.Errorf("ThreadParentID = %q, want %q", sub.ThreadParentID, msg.ID)
+	}
+	if sub.UserID != user.ID {
+		t.Errorf("UserID = %q, want %q", sub.UserID, user.ID)
+	}
+	if sub.Status != "subscribed" {
+		t.Errorf("Status = %q, want %q", sub.Status, "subscribed")
+	}
+	if sub.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+}
+
+func TestRepository_Subscribe_ResubscribeAfterUnsubscribe(t *testing.T) {
+	db := testutil.TestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	user := testutil.CreateTestUser(t, db, "user@example.com", "User")
+	ws := testutil.CreateTestWorkspace(t, db, user.ID, "Test WS")
+	ch := testutil.CreateTestChannel(t, db, ws.ID, user.ID, "general", "public")
+	msg := testutil.CreateTestMessage(t, db, ch.ID, user.ID, "thread parent")
+
+	// Subscribe, then unsubscribe, then re-subscribe
+	_, err := repo.Subscribe(ctx, msg.ID, user.ID)
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	unsub, err := repo.Unsubscribe(ctx, msg.ID, user.ID)
+	if err != nil {
+		t.Fatalf("Unsubscribe() error = %v", err)
+	}
+	if unsub.Status != "unsubscribed" {
+		t.Errorf("Status = %q, want %q", unsub.Status, "unsubscribed")
+	}
+
+	resub, err := repo.Subscribe(ctx, msg.ID, user.ID)
+	if err != nil {
+		t.Fatalf("re-Subscribe() error = %v", err)
+	}
+	if resub.Status != "subscribed" {
+		t.Errorf("Status = %q, want %q", resub.Status, "subscribed")
+	}
+	// ID should be preserved from the original insert (ON CONFLICT updates, not replaces)
+	if resub.ID != unsub.ID {
+		t.Errorf("ID changed after re-subscribe: %q != %q", resub.ID, unsub.ID)
+	}
+}
+
+func TestRepository_Unsubscribe_NewRow(t *testing.T) {
+	db := testutil.TestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	user := testutil.CreateTestUser(t, db, "user@example.com", "User")
+	ws := testutil.CreateTestWorkspace(t, db, user.ID, "Test WS")
+	ch := testutil.CreateTestChannel(t, db, ws.ID, user.ID, "general", "public")
+	msg := testutil.CreateTestMessage(t, db, ch.ID, user.ID, "thread parent")
+
+	sub, err := repo.Unsubscribe(ctx, msg.ID, user.ID)
+	if err != nil {
+		t.Fatalf("Unsubscribe() error = %v", err)
+	}
+	if sub.Status != "unsubscribed" {
+		t.Errorf("Status = %q, want %q", sub.Status, "unsubscribed")
+	}
+	if sub.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+}
+
+func TestRepository_GetSubscription_ReturnsNilForMissing(t *testing.T) {
+	db := testutil.TestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	sub, err := repo.GetSubscription(ctx, "nonexistent", "nonexistent")
+	if err != nil {
+		t.Fatalf("GetSubscription() error = %v", err)
+	}
+	if sub != nil {
+		t.Error("expected nil subscription for missing row")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `journal_size_limit` pragma (configurable, default 64MB WAL cap), bump default `cache_size` to 8MB, bump default `max_open_conns` to 10, and enable `mmap_size` at 256MB for better read performance
- Use `RETURNING` clause in thread subscribe/unsubscribe UPSERTs to eliminate redundant follow-up queries
- Replace the two-step UPDATE-then-INSERT in notification preferences with a single `INSERT...ON CONFLICT DO UPDATE...RETURNING`, fixing a TOCTOU race under concurrent access
- Return time parse errors in notification preferences instead of silently discarding them
- Update configuration and scaling docs to reflect new defaults

## Test plan
- [x] `make test` — all existing + new tests pass
- [x] `make lint` — clean
- [ ] `make dev` + `make seed` — verify app starts and queries work
- [ ] Test thread subscribe/unsubscribe and notification preference changes via web UI

Closes #252