### PR TITLE
Add 404 page to website

### DIFF
--- a/apps/website/src/404.njk
+++ b/apps/website/src/404.njk
@@ -1,0 +1,17 @@
+---
+layout: layouts/page.njk
+title: "Page not found"
+permalink: /404.html
+---
+
+<section class="flex-1 flex items-center justify-center py-24">
+  <div class="text-center max-w-md mx-auto px-4">
+    <h1 class="text-6xl font-bold text-gray-900 dark:text-white">404</h1>
+    <p class="mt-4 text-lg text-gray-600 dark:text-gray-400">
+      This page doesn't exist.
+    </p>
+    <a href="/" class="mt-8 inline-flex items-center px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors">
+      Back to home
+    </a>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- Adds `apps/website/src/404.njk` which Eleventy outputs as `_site/404.html`
- Simple page with header/footer, "404" heading, message, and back-to-home link

## Notes
The deploy repo's Caddyfile also needs a `handle_errors` block to serve this file. That will be a separate PR to enzyme/deploy.