### PR TITLE
Add deploy and provision workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,13 @@ jobs:
             enabled: true
             relay_url: https://push.enzyme.im
             include_preview: true
+
+          telemetry:
+            enabled: true
+            endpoint: localhost:4318
+            protocol: http
+            insecure: true
+            service_name: enzyme
           EOF
 
       - name: Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,214 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy-app:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Build
+        run: |
+          make install
+          make generate-types
+          pnpm --filter @enzyme/web build
+          cp -r apps/web/dist/ server/internal/web/dist/
+          cd server
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../enzyme ./cmd/enzyme
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Write config
+        run: |
+          cat <<'EOF' > /tmp/enzyme-config.yaml
+          log:
+            level: info
+            format: json
+
+          server:
+            host: 0.0.0.0
+            port: 8080
+            public_url: https://app.enzyme.im
+            allowed_origins: []
+            tls:
+              mode: "off"
+
+          database:
+            path: /var/lib/enzyme/data/enzyme.db
+            max_open_conns: 10
+
+          storage:
+            type: local
+            local:
+              path: /var/lib/enzyme/data/uploads
+
+          email:
+            enabled: true
+            host: ${{ secrets.SMTP_HOST }}
+            port: 587
+            username: ${{ secrets.SMTP_USERNAME }}
+            password: ${{ secrets.SMTP_PASSWORD }}
+            from: ${{ secrets.SMTP_FROM }}
+
+          push_notifications:
+            enabled: true
+            relay_url: https://push.enzyme.im
+            include_preview: true
+          EOF
+
+      - name: Deploy
+        run: |
+          ssh root@${{ secrets.SERVER_HOST }} "systemctl stop enzyme || true"
+          scp enzyme root@${{ secrets.SERVER_HOST }}:/opt/enzyme/enzyme
+          scp /tmp/enzyme-config.yaml root@${{ secrets.SERVER_HOST }}:/opt/enzyme/config.yaml
+          ssh root@${{ secrets.SERVER_HOST }} bash <<'SCRIPT'
+          chmod 755 /opt/enzyme/enzyme
+          chown root:root /opt/enzyme/enzyme
+          chmod 640 /opt/enzyme/config.yaml
+          chown root:enzyme /opt/enzyme/config.yaml
+          systemctl start enzyme
+          SCRIPT
+
+      - name: Health check
+        run: |
+          for i in $(seq 1 10); do
+            if ssh root@${{ secrets.SERVER_HOST }} "curl -sf http://localhost:8080/api/health" > /dev/null 2>&1; then
+              echo "Health check passed"
+              exit 0
+            fi
+            echo "Attempt $i/10 — waiting..."
+            sleep 2
+          done
+          echo "Health check failed"
+          ssh root@${{ secrets.SERVER_HOST }} "journalctl -u enzyme --no-pager -n 20"
+          exit 1
+
+  deploy-website:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Build
+        run: |
+          pnpm install --filter @enzyme/website...
+          pnpm --filter @enzyme/website build
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy
+        run: |
+          scp -r apps/website/_site/* root@${{ secrets.SERVER_HOST }}:/var/www/enzyme-website/
+
+  deploy-push:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
+      - name: Build
+        run: |
+          cd server
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ../push-relay ./cmd/push-relay/
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Write env config
+        run: |
+          cat <<'EOF' > /tmp/push-relay.env
+          RELAY_PORT=8090
+          RELAY_TRUST_PROXY=true
+          RELAY_LOG_LEVEL=info
+          RELAY_FCM_CREDENTIALS_FILE=/opt/enzyme/fcm-credentials.json
+          RELAY_APNS_KEY_FILE=/opt/enzyme/apns-key.p8
+          RELAY_APNS_KEY_ID=${{ secrets.APNS_KEY_ID }}
+          RELAY_APNS_TEAM_ID=${{ secrets.APNS_TEAM_ID }}
+          RELAY_APNS_BUNDLE_ID=im.enzyme.mobile
+          RELAY_APNS_PRODUCTION=true
+          EOF
+
+      - name: Deploy
+        run: |
+          ssh root@${{ secrets.SERVER_HOST }} "systemctl stop push-relay || true"
+          scp push-relay root@${{ secrets.SERVER_HOST }}:/opt/enzyme/push-relay
+          scp /tmp/push-relay.env root@${{ secrets.SERVER_HOST }}:/opt/enzyme/push-relay.env
+          ssh root@${{ secrets.SERVER_HOST }} bash <<SCRIPT
+          chmod 755 /opt/enzyme/push-relay
+          chown root:root /opt/enzyme/push-relay
+          chmod 640 /opt/enzyme/push-relay.env
+          chown root:enzyme /opt/enzyme/push-relay.env
+
+          if [ -n "${{ secrets.FCM_CREDENTIALS_JSON }}" ]; then
+            echo "${{ secrets.FCM_CREDENTIALS_JSON }}" | base64 -d > /opt/enzyme/fcm-credentials.json
+            chmod 640 /opt/enzyme/fcm-credentials.json
+            chown root:enzyme /opt/enzyme/fcm-credentials.json
+          fi
+
+          if [ -n "${{ secrets.APNS_KEY }}" ]; then
+            echo "${{ secrets.APNS_KEY }}" | base64 -d > /opt/enzyme/apns-key.p8
+            chmod 640 /opt/enzyme/apns-key.p8
+            chown root:enzyme /opt/enzyme/apns-key.p8
+          fi
+
+          systemctl start push-relay
+          SCRIPT
+
+      - name: Health check
+        run: |
+          for i in $(seq 1 10); do
+            if ssh root@${{ secrets.SERVER_HOST }} "curl -sf http://localhost:8090/health" > /dev/null 2>&1; then
+              echo "Health check passed"
+              exit 0
+            fi
+            echo "Attempt $i/10 — waiting..."
+            sleep 2
+          done
+          echo "Health check failed"
+          ssh root@${{ secrets.SERVER_HOST }} "journalctl -u push-relay --no-pager -n 20"
+          exit 1

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,0 +1,135 @@
+name: Provision Server
+
+on:
+  workflow_dispatch:
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H ${{ secrets.SERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: System setup
+        run: |
+          ssh root@${{ secrets.SERVER_HOST }} bash <<'SCRIPT'
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+
+          echo "==> System update"
+          apt-get update -qq
+          apt-get upgrade -y -qq
+
+          echo "==> Creating enzyme user"
+          id enzyme &>/dev/null || useradd --system --shell /usr/sbin/nologin enzyme
+
+          echo "==> Creating directories"
+          install -d -m 755 /opt/enzyme
+          install -d -m 750 -o enzyme -g enzyme /var/lib/enzyme/data
+          install -d -m 755 /var/www/enzyme-website
+
+          echo "==> Installing Caddy"
+          if ! command -v caddy &>/dev/null; then
+            apt-get install -y -qq debian-keyring debian-archive-keyring apt-transport-https curl
+            curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+            curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
+            apt-get update -qq
+            apt-get install -y -qq caddy
+          fi
+
+          echo "==> Configuring UFW"
+          ufw allow 22/tcp
+          ufw allow 80/tcp
+          ufw allow 443/tcp
+          ufw --force enable
+          SCRIPT
+
+      - name: Write Caddyfile
+        run: |
+          cat <<'EOF' | ssh root@${{ secrets.SERVER_HOST }} "cat > /etc/caddy/Caddyfile"
+          www.enzyme.im {
+            redir https://enzyme.im{uri} permanent
+          }
+
+          enzyme.im {
+            root * /var/www/enzyme-website
+            file_server
+            encode gzip
+            try_files {path} {path}/
+            handle_errors {
+              rewrite * /404.html
+              file_server
+            }
+          }
+
+          app.enzyme.im {
+            @sse path /api/sse*
+            reverse_proxy @sse localhost:8080 {
+              flush_interval -1
+            }
+            reverse_proxy localhost:8080
+          }
+
+          push.enzyme.im {
+            reverse_proxy localhost:8090
+          }
+          EOF
+
+      - name: Write enzyme.service
+        run: |
+          cat <<'EOF' | ssh root@${{ secrets.SERVER_HOST }} "cat > /etc/systemd/system/enzyme.service"
+          [Unit]
+          Description=Enzyme Chat Server
+          After=network.target
+
+          [Service]
+          Type=simple
+          User=enzyme
+          Group=enzyme
+          ExecStart=/opt/enzyme/enzyme --config /opt/enzyme/config.yaml
+          WorkingDirectory=/opt/enzyme
+          Restart=on-failure
+          RestartSec=5
+          LimitNOFILE=65535
+
+          NoNewPrivileges=true
+          ProtectSystem=strict
+          ProtectHome=true
+          ReadWritePaths=/var/lib/enzyme
+
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+
+      - name: Write push-relay.service
+        run: |
+          cat <<'EOF' | ssh root@${{ secrets.SERVER_HOST }} "cat > /etc/systemd/system/push-relay.service"
+          [Unit]
+          Description=Enzyme Push Relay
+          After=network.target
+
+          [Service]
+          Type=simple
+          User=enzyme
+          Group=enzyme
+          ExecStart=/opt/enzyme/push-relay
+          WorkingDirectory=/opt/enzyme
+          EnvironmentFile=/opt/enzyme/push-relay.env
+          Restart=on-failure
+          RestartSec=5
+
+          NoNewPrivileges=true
+          ProtectSystem=strict
+          ProtectHome=true
+
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+
+      - name: Enable services
+        run: |
+          ssh root@${{ secrets.SERVER_HOST }} "systemctl daemon-reload && systemctl reload caddy && systemctl enable enzyme push-relay caddy"

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -41,6 +41,14 @@ jobs:
             apt-get install -y -qq caddy
           fi
 
+          echo "==> Installing OpenTelemetry Collector"
+          if ! command -v otelcol-contrib &>/dev/null; then
+            curl -1sLf 'https://packages.opentelemetry.io/public/apt/gpg.key' | gpg --dearmor -o /usr/share/keyrings/otel-contrib-archive-keyring.gpg
+            echo "deb [signed-by=/usr/share/keyrings/otel-contrib-archive-keyring.gpg] https://packages.opentelemetry.io/public/apt/ stable main" | tee /etc/apt/sources.list.d/otelcol-contrib.list
+            apt-get update -qq
+            apt-get install -y -qq otelcol-contrib
+          fi
+
           echo "==> Configuring UFW"
           ufw allow 22/tcp
           ufw allow 80/tcp
@@ -130,6 +138,55 @@ jobs:
           WantedBy=multi-user.target
           EOF
 
+      - name: Write otelcol-contrib config
+        run: |
+          cat <<EOF | ssh root@${{ secrets.SERVER_HOST }} "cat > /etc/otelcol-contrib/config.yaml"
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: localhost:4317
+                http:
+                  endpoint: localhost:4318
+            hostmetrics:
+              collection_interval: 60s
+              scrapers:
+                cpu:
+                memory:
+                disk:
+                filesystem:
+                network:
+                load:
+
+          processors:
+            batch:
+            resourcedetection:
+              detectors: ["env", "system"]
+              override: false
+
+          exporters:
+            otlphttp:
+              endpoint: https://api.honeycomb.io
+              headers:
+                x-honeycomb-team: ${{ secrets.HONEYCOMB_API_KEY }}
+              compression: gzip
+
+          service:
+            pipelines:
+              traces:
+                receivers: [otlp]
+                processors: [resourcedetection, batch]
+                exporters: [otlphttp]
+              metrics:
+                receivers: [otlp, hostmetrics]
+                processors: [resourcedetection, batch]
+                exporters: [otlphttp]
+              logs:
+                receivers: [otlp]
+                processors: [resourcedetection, batch]
+                exporters: [otlphttp]
+          EOF
+
       - name: Enable services
         run: |
-          ssh root@${{ secrets.SERVER_HOST }} "systemctl daemon-reload && systemctl reload caddy && systemctl enable enzyme push-relay caddy"
+          ssh root@${{ secrets.SERVER_HOST }} "systemctl daemon-reload && systemctl reload caddy && systemctl restart otelcol-contrib && systemctl enable enzyme push-relay caddy otelcol-contrib"


### PR DESCRIPTION
## Summary

Moves all deployment logic into the monorepo as GitHub Actions workflows, eliminating the need for the separate `enzyme/deploy` repo.

**`provision.yml`** (manual trigger) — sets up a fresh Ubuntu droplet:
- Creates enzyme user, directories
- Installs Caddy, writes Caddyfile (with www redirect + 404 handler)
- Writes systemd units for enzyme and push-relay
- Configures UFW

**`deploy.yml`** (on push to main + manual) — three parallel jobs:
- **deploy-app**: builds frontend + backend from source, deploys binary + config
- **deploy-website**: builds Eleventy site, SCPs to server
- **deploy-push**: builds push-relay binary, deploys with env config (`continue-on-error: true` since FCM/APNs credentials aren't configured yet)

## Setup required

Add these secrets to enzyme/enzyme:
- `SSH_PRIVATE_KEY` — SSH key for root@enzyme.im
- `SERVER_HOST` — `enzyme.im`
- `SMTP_HOST`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`

Push secrets (deferred): `FCM_CREDENTIALS_JSON`, `APNS_KEY`, `APNS_KEY_ID`, `APNS_TEAM_ID`

## Supersedes

These PRs/repos can be closed once this lands:
- enzyme/deploy#4, enzyme/deploy#5
- The `enzyme/deploy` repo itself