### PR TITLE
Fix deploy workflow: pnpm version conflict and health check URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,6 @@ jobs:
           cache-dependency-path: server/go.sum
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:
@@ -102,7 +100,7 @@ jobs:
       - name: Health check
         run: |
           for i in $(seq 1 10); do
-            if ssh root@${{ secrets.SERVER_HOST }} "curl -sf http://localhost:8080/api/health" > /dev/null 2>&1; then
+            if ssh root@${{ secrets.SERVER_HOST }} "curl -sf http://localhost:8080/health" > /dev/null 2>&1; then
               echo "Health check passed"
               exit 0
             fi
@@ -119,8 +117,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Remove explicit `version: 9` from `pnpm/action-setup@v4` in deploy-app and deploy-website jobs — conflicts with `packageManager: "pnpm@9.15.0"` in package.json
- Fix app health check endpoint from `/api/health` to `/health` (the health route is on the root router, not under the `/api` prefix)

## Context
The initial deploy run from #256 failed all three jobs:
- **deploy-app** and **deploy-website**: `pnpm/action-setup@v4` errors with "Multiple versions of pnpm specified"
- **deploy-push**: Health check hit wrong URL (deploy itself succeeded, health check failure is expected without FCM/APNs creds anyway since it has `continue-on-error`)