### PR TITLE
Remove generate-types from deploy build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Build
         run: |
           make install
-          make generate-types
           pnpm --filter @enzyme/web build
           cp -r apps/web/dist/ server/internal/web/dist/
           cd server


### PR DESCRIPTION
## Summary
- Remove `make generate-types` from deploy-app build step — generated files (`server.gen.go`, `schema.ts`) are committed and CI verifies they stay in sync
- This caused deploy-app to fail because `oapi-codegen` isn't installed on the deploy runner

## Context
Follow-up to #257. The deploy-app build step was running `make generate-types` which requires `oapi-codegen`, a Go tool not present on the runner. Since the generated code is committed and CI already validates it's up to date, the deploy can just build directly.