### PR TITLE
Update chat.enzyme.im references to app.enzyme.im

### DIFF
--- a/apps/load-tests/README.md
+++ b/apps/load-tests/README.md
@@ -40,8 +40,8 @@ make load-test-sse-stress                        # 100 connections, 2m
 make load-test-sse-stress SSE_CONNECTIONS=2000   # 2000 connections
 
 # Against a remote server
-make load-test K6_BASE_URL=https://chat.enzyme.im
-make load-test-sse-stress K6_BASE_URL=https://chat.enzyme.im SSE_CONNECTIONS=2000
+make load-test K6_BASE_URL=https://app.enzyme.im
+make load-test-sse-stress K6_BASE_URL=https://app.enzyme.im SSE_CONNECTIONS=2000
 ```
 
 ## Development
@@ -92,5 +92,5 @@ rm server/enzyme.db && make seed
 By default, load tests refuse to run against non-localhost servers. To run against a remote target, set `K6_CONFIRM_REMOTE=1`:
 
 ```bash
-make load-test K6_BASE_URL=https://chat.enzyme.im K6_FLAGS="--env K6_CONFIRM_REMOTE=1"
+make load-test K6_BASE_URL=https://app.enzyme.im K6_FLAGS="--env K6_CONFIRM_REMOTE=1"
 ```

--- a/apps/website/src/_data/site.json
+++ b/apps/website/src/_data/site.json
@@ -1,5 +1,5 @@
 {
   "url": "https://enzyme.im",
   "githubUrl": "https://github.com/enzyme/enzyme",
-  "appUrl": "https://chat.enzyme.im"
+  "appUrl": "https://app.enzyme.im"
 }


### PR DESCRIPTION
## Summary
- Update app URL from `chat.enzyme.im` to `app.enzyme.im` in the website config and load test docs

## Test plan
- [ ] Verify marketing site links point to `app.enzyme.im`
- [ ] Verify load test README examples use the correct remote URL