### PR TITLE
Fix production deploy: web client embed and telemetry defaults

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           make install
           pnpm --filter @enzyme/web build
-          cp -r apps/web/dist/ server/internal/web/dist/
+          rm -rf server/internal/web/dist && cp -r apps/web/dist server/internal/web/dist
           cd server
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../enzyme ./cmd/enzyme
 


### PR DESCRIPTION
## Summary
- **Web client 404**: `cp -r apps/web/dist/ server/internal/web/dist/` creates a nested `dist/dist/` on GNU cp (Linux CI), so `HasContent()` can't find `dist/index.html` and the SPA handler is never mounted. Confirmed via server logs and `dist/dist/` path in the deployed binary.
- **Missing traces/logs**: The koanf defaults provider map was missing `traces`, `metrics`, `logs`, and `frontend_endpoint` fields, so they always resolved to `false` even though `Defaults()` sets them to `true`. Host metrics worked because they come from the otel collector, not the Go server.
- **Host metrics in unknown_metrics**: The otel collector's `hostmetrics` receiver doesn't set `service.name`, so Honeycomb routes them to "unknown_metrics". Added a `resource` processor with `action: insert` to set it only when missing.

## Test plan
- [ ] Merge and verify deploy succeeds
- [ ] `https://app.enzyme.im/` serves the web client instead of 404
- [ ] Server logs show `"embedded web client enabled"`
- [ ] Traces and logs appear in Honeycomb under the `enzyme` service
- [ ] Re-run provision workflow, then verify host metrics no longer go to `unknown_metrics`